### PR TITLE
Add analytics foundation and ranked BDD roadmap

### DIFF
--- a/docs/backlog/01-analytics-foundation.feature
+++ b/docs/backlog/01-analytics-foundation.feature
@@ -1,0 +1,38 @@
+# ROI: Very High
+# Psych leverage: High, because it tells us which encoding and retrieval behaviors actually help.
+# Tech leverage: Very High, because later review, personalization, and dashboards depend on it.
+
+Feature: Analytics foundation for memory outcomes
+  In order to improve memorization with evidence instead of guesswork
+  As a serious learner
+  I want the app to capture meaningful learning and review telemetry
+
+  Background:
+    Given the app already supports palaces, nodes, routes, walk mode, and draft recovery
+
+  Scenario: Track retrieval outcome per step
+    Given a user is reviewing a route in walk mode
+    When the user reveals an answer and rates recall quality
+    Then the app records the route, node, timestamp, recall quality, and time to reveal
+
+  Scenario: Track encoding effort
+    Given a user creates or edits nodes and edges
+    When the user spends time encoding and restructuring material
+    Then the app records session-level counts for nodes, edges, routes, edits, and review actions
+
+  Scenario: Preserve privacy and local-first behavior
+    Given analytics are enabled
+    When telemetry is written
+    Then the data stays local by default
+    And the user can inspect what is being tracked
+
+  Scenario: Support later analytics features
+    Given review telemetry exists
+    When later features request strength, weak zones, overdue items, or theme effectiveness
+    Then the analytics model supports those queries without schema rewrites
+
+  Scenario: Survive app restarts
+    Given a user has prior review history
+    When the app restarts
+    Then analytics history remains available for dashboards and scheduling
+

--- a/docs/backlog/02-recall-first-walk-mode.feature
+++ b/docs/backlog/02-recall-first-walk-mode.feature
@@ -1,0 +1,40 @@
+# ROI: Very High
+# Psych leverage: Very High, because forced retrieval beats passive rereading.
+# Tech leverage: High, because it creates the rating events needed for adaptive review.
+
+Feature: Recall-first walk mode
+  In order to strengthen retrieval instead of recognition
+  As a learner
+  I want walk mode to test me before showing the answer
+
+  Background:
+    Given analytics foundation exists
+    And a route contains ordered loci
+
+  Scenario: Hide answer until reveal
+    Given the user starts recall-first mode
+    When a step is shown
+    Then the app shows only the cue, locus, and minimal prompt
+    And the full answer stays hidden until reveal
+
+  Scenario: Grade recall after reveal
+    Given the user reveals the answer
+    When the user grades recall as fail, hard, good, or easy
+    Then the result is stored for the current node and route step
+
+  Scenario: Support cue-only mode
+    Given a node has title and content
+    When cue-only mode is active
+    Then the app shows the cue first
+    And the full explanation appears only after reveal
+
+  Scenario: Preserve step stability
+    Given the user is stepping through a route
+    When recall-first controls are rendered
+    Then the controls stay spatially stable and easy to click
+
+  Scenario: Feed later scheduling
+    Given the user has completed a recall-first session
+    When the session ends
+    Then the graded results are available to the spaced review queue
+

--- a/docs/backlog/03-spaced-review-queue.feature
+++ b/docs/backlog/03-spaced-review-queue.feature
@@ -1,0 +1,39 @@
+# ROI: Very High
+# Psych leverage: Very High, because spacing turns one good review into long-term retention.
+# Tech leverage: High, because it creates the persistent review engine for the app.
+
+Feature: Spaced review queue
+  In order to revisit information at the right time
+  As a learner
+  I want the app to schedule reviews based on actual recall performance
+
+  Background:
+    Given recall-first ratings are stored
+    And analytics history exists for each reviewed node
+
+  Scenario: Compute next due date from recall quality
+    Given a node was graded during review
+    When the session is completed
+    Then the app computes the next review date using that grade
+
+  Scenario: Build a due queue
+    Given multiple nodes and routes have next review dates
+    When the user opens the review queue
+    Then the app orders due and overdue items ahead of fresh or stable ones
+
+  Scenario: Review at node and route levels
+    Given some material is best reviewed as a route
+    And some material is best reviewed as a single concept
+    When the queue is generated
+    Then the app can schedule both node-level and route-level review items
+
+  Scenario: Prevent silent neglect
+    Given a palace has overdue material
+    When the user opens the app
+    Then the interface makes overdue review visible without blocking normal graph work
+
+  Scenario: Stay local and persistent
+    Given spaced review data has been generated
+    When the app restarts
+    Then the queue and due dates persist
+

--- a/docs/backlog/04-memory-strength-dashboard.feature
+++ b/docs/backlog/04-memory-strength-dashboard.feature
@@ -1,0 +1,37 @@
+# ROI: High
+# Psych leverage: High, because visible weakness changes study behavior.
+# Tech leverage: High, because it turns raw telemetry into decisions.
+
+Feature: Memory strength dashboard
+  In order to focus on weak and decaying knowledge
+  As a learner
+  I want a dashboard that shows memory strength, overdue review, and trend data
+
+  Background:
+    Given analytics and spaced review data exist
+
+  Scenario: Show weak and overdue material
+    Given nodes and routes have review history
+    When the user opens the dashboard
+    Then the app highlights weak, unstable, and overdue material first
+
+  Scenario: Show palace-level health
+    Given a palace contains many nodes and routes
+    When the dashboard is rendered
+    Then the user can see aggregate strength, review load, and failure hotspots for that palace
+
+  Scenario: Show trend over time
+    Given the user has completed multiple review sessions
+    When the dashboard is rendered
+    Then the user can see whether recall is improving, stagnating, or decaying
+
+  Scenario: Show route friction
+    Given a route consistently causes hesitation or failure
+    When the dashboard is rendered
+    Then the route is marked as cognitively expensive or unstable
+
+  Scenario: Drive action
+    Given weak or overdue material exists
+    When the user clicks a dashboard item
+    Then the app opens the related palace, node, or route and starts the appropriate review flow
+

--- a/docs/backlog/05-semantic-magic-theme-engine.feature
+++ b/docs/backlog/05-semantic-magic-theme-engine.feature
@@ -1,0 +1,38 @@
+# ROI: High
+# Psych leverage: High when effects encode meaning, low when they are only decorative.
+# Tech leverage: Medium, because this is mostly UX unless it is tied to analytics and review states.
+
+Feature: Semantic magic theme engine
+  In order to make material more distinctive and emotionally salient
+  As a learner
+  I want neon, glow, and magical effects to carry mnemonic meaning
+
+  Background:
+    Given the core review and analytics loop exists
+
+  Scenario: Encode meaning through visual effects
+    Given nodes and edges have semantic states
+    When the graph is rendered
+    Then visual effects map to meaning such as stable, weak, overdue, causal, dangerous, or portal
+
+  Scenario: Avoid uniform glow
+    Given a palace contains many objects
+    When magic styling is applied
+    Then not every object receives the same glow treatment
+    And the strongest effects are reserved for the most important distinctions
+
+  Scenario: Link visuals to review state
+    Given review strength data exists
+    When a node is weak or overdue
+    Then its visual treatment reflects that state in a stable and legible way
+
+  Scenario: Theme a palace intentionally
+    Given a user wants a palace to feel like a neon district, ritual chamber, or storm archive
+    When the user applies a theme
+    Then the theme affects the palace consistently without harming readability
+
+  Scenario: Respect performance
+    Given a large palace is open
+    When effects are enabled
+    Then animation and glow do not make the app feel sluggish or noisy
+

--- a/docs/backlog/06-encoding-assistant.feature
+++ b/docs/backlog/06-encoding-assistant.feature
@@ -1,0 +1,37 @@
+# ROI: High
+# Psych leverage: Very High, because vivid self-generated imagery sticks better than flat text.
+# Tech leverage: Medium, because it needs good UX more than deep infrastructure.
+
+Feature: Encoding assistant
+  In order to turn dry facts into memorable material
+  As a learner
+  I want the app to help transform plain notes into vivid memory cues
+
+  Background:
+    Given a user can create or edit memory nodes
+
+  Scenario: Suggest vivid encodings
+    Given a node contains abstract or dry text
+    When the user invokes the encoding assistant
+    Then the app suggests image, action, emotion, exaggeration, and place cues
+
+  Scenario: Generate multiple styles
+    Given the same source concept
+    When the user requests encoding help
+    Then the app can offer serious, bizarre, and highly visual variants
+
+  Scenario: Preserve user authorship
+    Given the app suggests an encoding
+    When the user chooses one
+    Then the user can edit and personalize it before saving
+
+  Scenario: Connect encoding to palace placement
+    Given a user selects a palace locus
+    When the encoding assistant generates suggestions
+    Then the suggestions can reference that place explicitly
+
+  Scenario: Improve later recall
+    Given a generated encoding is used in review
+    When analytics compare encoded vs non-encoded material
+    Then the app can later show whether the encoding style is helping
+

--- a/docs/backlog/07-contrast-and-confusion-nodes.feature
+++ b/docs/backlog/07-contrast-and-confusion-nodes.feature
@@ -1,0 +1,37 @@
+# ROI: High
+# Psych leverage: High, because many memory failures are confusion and interference failures.
+# Tech leverage: Medium, because it mainly extends the node model and review prompts.
+
+Feature: Contrast and confusion nodes
+  In order to reduce concept collisions and false recall
+  As a learner
+  I want first-class support for confusions, contrasts, and "not this" explanations
+
+  Background:
+    Given the user is learning concepts that are similar or easily mixed up
+
+  Scenario: Mark a common confusion
+    Given two concepts are easy to confuse
+    When the user links them as a confusion pair
+    Then the app records that relationship explicitly
+
+  Scenario: Store "what this is not"
+    Given a node is prone to fuzzy understanding
+    When the user adds a contrast note
+    Then the node can display what it is not and why
+
+  Scenario: Use confusion in review
+    Given a concept has known collisions
+    When the user reviews it
+    Then the app can ask discrimination-style questions instead of only recall questions
+
+  Scenario: Surface collisions in analytics
+    Given multiple failures cluster around the same concept pair
+    When analytics are computed
+    Then the dashboard marks that pair as a confusion hotspot
+
+  Scenario: Preserve graph clarity
+    Given confusion links exist
+    When the graph is rendered
+    Then confusion links are visually distinct from normal semantic or CAST links
+

--- a/docs/backlog/08-media-cues.feature
+++ b/docs/backlog/08-media-cues.feature
@@ -1,0 +1,37 @@
+# ROI: Medium to High
+# Psych leverage: High through dual coding, but only after review and analytics are already in place.
+# Tech leverage: Medium, because storage and playback add complexity.
+
+Feature: Media cues for dual coding
+  In order to strengthen memory through multiple channels
+  As a learner
+  I want nodes and palaces to support image and audio cues
+
+  Background:
+    Given the user has already encoded concepts into nodes and routes
+
+  Scenario: Attach an image cue to a node
+    Given a node benefits from visual reinforcement
+    When the user adds an image cue
+    Then the image is attached, persisted, and available during review
+
+  Scenario: Attach an audio cue to a node
+    Given pronunciation, rhythm, or emotional tone matters
+    When the user adds an audio cue
+    Then the cue can be played during review and persists across restarts
+
+  Scenario: Use media selectively
+    Given a palace contains many nodes
+    When media cues are added
+    Then the user can keep media on only the highest-value concepts instead of cluttering everything
+
+  Scenario: Integrate media into review
+    Given a node has media cues
+    When the user reviews that node
+    Then the review flow can reveal media as an optional reinforcement layer
+
+  Scenario: Keep performance and storage reasonable
+    Given many media assets exist
+    When the palace loads
+    Then the app remains responsive and does not degrade into asset management overhead
+

--- a/docs/backlog/DELIVERY_PROCESS.md
+++ b/docs/backlog/DELIVERY_PROCESS.md
@@ -1,0 +1,47 @@
+# Delivery Process
+
+This file defines how backlog items in this folder should be delivered.
+
+## Rules
+
+1. Only implement one ranked backlog item at a time.
+2. Do not begin the next item until the current item is verified and committed.
+3. Always preserve existing user data and current workflows unless the story explicitly changes them.
+4. Prefer infrastructure that can support later items over one-off hacks.
+
+## Required Verification Before Commit
+
+Run at minimum:
+
+```powershell
+npm.cmd run typecheck
+npm.cmd test
+npx.cmd playwright test --workers=1
+npm.cmd run build
+```
+
+If Tauri config, commands, or database code changed, also run:
+
+```powershell
+cargo check
+```
+
+## Commit Gate
+
+Do not commit unless:
+- the target feature is complete enough to be useful
+- the acceptance scenarios in its `.feature` file are satisfied
+- the verification commands above are green
+- no unrelated regressions were introduced
+
+## Execution Order
+
+1. `01-analytics-foundation.feature`
+2. `02-recall-first-walk-mode.feature`
+3. `03-spaced-review-queue.feature`
+4. `04-memory-strength-dashboard.feature`
+5. `05-semantic-magic-theme-engine.feature`
+6. `06-encoding-assistant.feature`
+7. `07-contrast-and-confusion-nodes.feature`
+8. `08-media-cues.feature`
+

--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -1,0 +1,47 @@
+# Memory Palace ROI Backlog
+
+This backlog ranks high-ROI features from both technical and psychological perspectives.
+
+Execution rule:
+- Work top to bottom.
+- Finish one file before starting the next.
+- Run tests before every commit.
+- Do not commit if verification is red.
+
+Ranking logic:
+- `ROI` favors features that improve recall, reduce loss of work, or create measurable learning gains.
+- `Psych` captures memory science leverage: retrieval, spacing, distinctiveness, dual coding, chunking, and interference reduction.
+- `Tech` captures platform leverage: reusable infrastructure, observability, and features that unlock later work.
+
+## Rank Order
+
+1. [Analytics Foundation](./01-analytics-foundation.feature)
+   Why first: everything after this gets smarter if we can measure what actually helps.
+
+2. [Recall-First Walk Mode](./02-recall-first-walk-mode.feature)
+   Why second: forced retrieval is the strongest direct memory upgrade.
+
+3. [Spaced Review Queue](./03-spaced-review-queue.feature)
+   Why third: retrieval becomes durable only when the schedule adapts over time.
+
+4. [Memory Strength Dashboard](./04-memory-strength-dashboard.feature)
+   Why fourth: analytics becomes actionable only when weak areas are visible.
+
+5. [Semantic Magic Theme Engine](./05-semantic-magic-theme-engine.feature)
+   Why fifth: neon and magic become useful when they encode meaning instead of decoration.
+
+6. [Encoding Assistant](./06-encoding-assistant.feature)
+   Why sixth: dry facts need help becoming vivid, image-rich memory material.
+
+7. [Contrast and Confusion Nodes](./07-contrast-and-confusion-nodes.feature)
+   Why seventh: confusion is often a discrimination problem, not a storage problem.
+
+8. [Media Cues](./08-media-cues.feature)
+   Why eighth: images and audio add dual coding, but only after the core review loop exists.
+
+## Delivery Notes
+
+- `01` through `04` are the cognitive core.
+- `05` is where the interface becomes more magical without sacrificing precision.
+- `06` through `08` expand encoding power once analytics and review loops are stable.
+

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,4 +1,7 @@
-use crate::db::{create_palace, list_palaces, load_palace, save_snapshot, PalaceDto, PalaceSnapshot};
+use crate::db::{
+    append_analytics_events, create_palace, list_analytics_events, list_palaces, load_palace,
+    save_snapshot, AnalyticsEventDto, PalaceDto, PalaceSnapshot,
+};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -36,6 +39,24 @@ pub fn palace_load(state: State<DbState>, palace_id: String) -> Result<Option<Pa
 pub fn palace_save(state: State<DbState>, snapshot: PalaceSnapshot) -> Result<(), String> {
     let mut conn = open(&state)?;
     save_snapshot(&mut conn, &snapshot).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn analytics_list(
+    state: State<DbState>,
+    limit: Option<usize>,
+) -> Result<Vec<AnalyticsEventDto>, String> {
+    let conn = open(&state)?;
+    list_analytics_events(&conn, limit).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub fn analytics_append(
+    state: State<DbState>,
+    events: Vec<AnalyticsEventDto>,
+) -> Result<(), String> {
+    let mut conn = open(&state)?;
+    append_analytics_events(&mut conn, &events).map_err(|e| e.to_string())
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -74,6 +74,25 @@ pub struct LocusDto {
     pub label: String,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AnalyticsEventDto {
+    pub id: String,
+    #[serde(default)]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub palace_id: Option<String>,
+    #[serde(default)]
+    pub route_id: Option<String>,
+    #[serde(default)]
+    pub node_id: Option<String>,
+    pub event_type: String,
+    pub event_group: String,
+    pub created_at: String,
+    #[serde(default = "default_payload_json")]
+    pub payload_json: String,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PalaceSnapshot {
@@ -90,6 +109,10 @@ fn default_node_kind() -> String {
 }
 
 fn default_node_meta_json() -> String {
+    "{}".to_string()
+}
+
+fn default_payload_json() -> String {
     "{}".to_string()
 }
 
@@ -153,10 +176,26 @@ pub fn init_db(path: &Path) -> rusqlite::Result<()> {
             label TEXT NOT NULL DEFAULT ''
         );
 
+        CREATE TABLE IF NOT EXISTS analytics_events (
+            id TEXT PRIMARY KEY NOT NULL,
+            session_id TEXT,
+            palace_id TEXT REFERENCES palaces(id) ON DELETE SET NULL,
+            route_id TEXT REFERENCES routes(id) ON DELETE SET NULL,
+            node_id TEXT REFERENCES nodes(id) ON DELETE SET NULL,
+            event_type TEXT NOT NULL,
+            event_group TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            payload_json TEXT NOT NULL DEFAULT '{}'
+        );
+
         CREATE INDEX IF NOT EXISTS idx_canvas_palace ON canvas_objects(palace_id);
         CREATE INDEX IF NOT EXISTS idx_nodes_object ON nodes(object_id);
         CREATE INDEX IF NOT EXISTS idx_routes_palace ON routes(palace_id);
         CREATE INDEX IF NOT EXISTS idx_loci_route ON loci(route_id);
+        CREATE INDEX IF NOT EXISTS idx_analytics_created_at ON analytics_events(created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_analytics_session ON analytics_events(session_id);
+        CREATE INDEX IF NOT EXISTS idx_analytics_palace ON analytics_events(palace_id);
+        CREATE INDEX IF NOT EXISTS idx_analytics_event_type ON analytics_events(event_type);
         "#,
     )?;
     // Lightweight migration for existing DBs created before locus labels.
@@ -189,6 +228,43 @@ pub fn init_db(path: &Path) -> rusqlite::Result<()> {
             _ => return Err(err),
         }
     }
+    if let Err(err) = conn.execute("ALTER TABLE analytics_events ADD COLUMN session_id TEXT", []) {
+        match err {
+            rusqlite::Error::SqliteFailure(_, Some(msg)) if msg.contains("duplicate column name") => {}
+            rusqlite::Error::SqliteFailure(_, Some(msg)) if msg.contains("no such table") => {}
+            _ => return Err(err),
+        }
+    }
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS analytics_events (
+            id TEXT PRIMARY KEY NOT NULL,
+            session_id TEXT,
+            palace_id TEXT REFERENCES palaces(id) ON DELETE SET NULL,
+            route_id TEXT REFERENCES routes(id) ON DELETE SET NULL,
+            node_id TEXT REFERENCES nodes(id) ON DELETE SET NULL,
+            event_type TEXT NOT NULL,
+            event_group TEXT NOT NULL,
+            created_at TEXT NOT NULL,
+            payload_json TEXT NOT NULL DEFAULT '{}'
+        )",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_created_at ON analytics_events(created_at DESC)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_session ON analytics_events(session_id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_palace ON analytics_events(palace_id)",
+        [],
+    )?;
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_analytics_event_type ON analytics_events(event_type)",
+        [],
+    )?;
     Ok(())
 }
 
@@ -469,6 +545,101 @@ pub fn save_snapshot(conn: &mut Connection, snap: &PalaceSnapshot) -> rusqlite::
         )?;
     }
 
+    tx.commit()?;
+    Ok(())
+}
+
+pub fn list_analytics_events(
+    conn: &Connection,
+    limit: Option<usize>,
+) -> rusqlite::Result<Vec<AnalyticsEventDto>> {
+    let sql = if limit.unwrap_or(0) > 0 {
+        "SELECT id, session_id, palace_id, route_id, node_id, event_type, event_group, created_at, payload_json
+         FROM analytics_events
+         ORDER BY created_at DESC
+         LIMIT ?1"
+    } else {
+        "SELECT id, session_id, palace_id, route_id, node_id, event_type, event_group, created_at, payload_json
+         FROM analytics_events
+         ORDER BY created_at DESC"
+    };
+
+    let mut stmt = conn.prepare(sql)?;
+    let rows = if let Some(limit) = limit {
+        if limit > 0 {
+            stmt.query_map(params![limit as i64], |r| {
+                Ok(AnalyticsEventDto {
+                    id: r.get(0)?,
+                    session_id: r.get(1)?,
+                    palace_id: r.get(2)?,
+                    route_id: r.get(3)?,
+                    node_id: r.get(4)?,
+                    event_type: r.get(5)?,
+                    event_group: r.get(6)?,
+                    created_at: r.get(7)?,
+                    payload_json: r.get(8)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+        } else {
+            stmt.query_map([], |r| {
+                Ok(AnalyticsEventDto {
+                    id: r.get(0)?,
+                    session_id: r.get(1)?,
+                    palace_id: r.get(2)?,
+                    route_id: r.get(3)?,
+                    node_id: r.get(4)?,
+                    event_type: r.get(5)?,
+                    event_group: r.get(6)?,
+                    created_at: r.get(7)?,
+                    payload_json: r.get(8)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?
+        }
+    } else {
+        stmt.query_map([], |r| {
+            Ok(AnalyticsEventDto {
+                id: r.get(0)?,
+                session_id: r.get(1)?,
+                palace_id: r.get(2)?,
+                route_id: r.get(3)?,
+                node_id: r.get(4)?,
+                event_type: r.get(5)?,
+                event_group: r.get(6)?,
+                created_at: r.get(7)?,
+                payload_json: r.get(8)?,
+            })
+        })?
+        .collect::<Result<Vec<_>, _>>()?
+    };
+
+    Ok(rows)
+}
+
+pub fn append_analytics_events(
+    conn: &mut Connection,
+    events: &[AnalyticsEventDto],
+) -> rusqlite::Result<()> {
+    let tx = conn.transaction()?;
+    for event in events {
+        tx.execute(
+            "INSERT OR REPLACE INTO analytics_events
+             (id, session_id, palace_id, route_id, node_id, event_type, event_group, created_at, payload_json)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+            params![
+                event.id,
+                event.session_id,
+                event.palace_id,
+                event.route_id,
+                event.node_id,
+                event.event_type,
+                event.event_group,
+                event.created_at,
+                event.payload_json
+            ],
+        )?;
+    }
     tx.commit()?;
     Ok(())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,7 +1,10 @@
 mod commands;
 mod db;
 
-use commands::{db_ping, palace_create, palace_export_json, palace_import_json, palace_list, palace_load, palace_save, DbState};
+use commands::{
+    analytics_append, analytics_list, db_ping, palace_create, palace_export_json, palace_import_json,
+    palace_list, palace_load, palace_save, DbState,
+};
 use std::fs;
 use tauri::Manager;
 
@@ -20,6 +23,8 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
+            analytics_list,
+            analytics_append,
             palace_list,
             palace_create,
             palace_load,

--- a/src/app/MemoryPalaceApp.tsx
+++ b/src/app/MemoryPalaceApp.tsx
@@ -20,6 +20,8 @@ export function MemoryPalaceApp() {
   const persistenceState = usePalaceStore((s) => s.persistenceState);
   const draftRestored = usePalaceStore((s) => s.draftRestored);
   const lastDraftSavedAt = usePalaceStore((s) => s.lastDraftSavedAt);
+  const analyticsLoaded = usePalaceStore((s) => s.analyticsLoaded);
+  const loadAnalyticsEvents = usePalaceStore((s) => s.loadAnalyticsEvents);
   const [showOnboarding, setShowOnboarding] = useState(true);
   const [showSidebar, setShowSidebar] = useState(true);
   const [showInspector, setShowInspector] = useState(true);
@@ -55,6 +57,12 @@ export function MemoryPalaceApp() {
     }
     return "Local · SQLite · Saved checkpoint";
   }, [currentPalace, draftRestored, lastDraftSavedAt, persistenceState]);
+
+  useEffect(() => {
+    if (!analyticsLoaded) {
+      void loadAnalyticsEvents();
+    }
+  }, [analyticsLoaded, loadAnalyticsEvents]);
 
   useEffect(() => {
     const flushDraft = () => {

--- a/src/canvas/MemoryPalaceCanvas.tsx
+++ b/src/canvas/MemoryPalaceCanvas.tsx
@@ -4,6 +4,7 @@ import type { Editor, TLGeoShape, TLEventInfo } from "@tldraw/editor";
 import type { TLShapeId, TLStoreSnapshot } from "@tldraw/tlschema";
 import "tldraw/tldraw.css";
 import { usePalaceStore } from "../store/palaceStore";
+import { captureSceneAnalyticsSnapshot, diffSceneAnalyticsSnapshots } from "./analyticsSceneSnapshot";
 import { createGeoMemoryNode } from "./createMemoryShapes";
 import type { MemoryPalaceMeta } from "./memoryMeta";
 import { nodeKindFromMeta, portalRefFromMeta } from "./palacePortal";
@@ -42,10 +43,12 @@ export function MemoryPalaceCanvas({ palaceId, editorSnapshot }: Props) {
 
   const editorRef = useRef<Editor | null>(null);
   const lastWalkNodeIdRef = useRef<string | null>(null);
+  const lastSceneSnapshotRef = useRef<ReturnType<typeof captureSceneAnalyticsSnapshot> | null>(null);
 
   const onMount = useCallback(
     (editor: Editor) => {
       editorRef.current = editor;
+      lastSceneSnapshotRef.current = captureSceneAnalyticsSnapshot(editor);
       setEditor(editor);
 
       const onEvent = (info: TLEventInfo) => {
@@ -130,7 +133,19 @@ export function MemoryPalaceCanvas({ palaceId, editorSnapshot }: Props) {
       const unsubDraft = editor.store.listen(
         () => {
           if (usePalaceStore.getState().currentPalace?.id !== palaceId) return;
+          const nextSnapshot = captureSceneAnalyticsSnapshot(editor);
+          const analyticsDiff = diffSceneAnalyticsSnapshots(lastSceneSnapshotRef.current, nextSnapshot);
+          lastSceneSnapshotRef.current = nextSnapshot;
           queueDraftSave();
+          for (const event of analyticsDiff) {
+            void usePalaceStore.getState().recordAnalyticsEvent({
+              eventType: event.eventType,
+              eventGroup: "graph",
+              palaceId,
+              nodeId: event.nodeId ?? null,
+              payload: event.payload,
+            });
+          }
         },
         { source: "user", scope: "document" },
       );
@@ -140,6 +155,7 @@ export function MemoryPalaceCanvas({ palaceId, editorSnapshot }: Props) {
         unsubSel();
         unsubDraft();
         setEditor(null);
+        lastSceneSnapshotRef.current = null;
         editorRef.current = null;
       };
     },

--- a/src/canvas/analyticsSceneSnapshot.ts
+++ b/src/canvas/analyticsSceneSnapshot.ts
@@ -1,0 +1,163 @@
+import type { Editor } from "@tldraw/editor";
+import type { AnalyticsEventType } from "../domain/entities/types";
+import type { MemoryPalaceMeta } from "./memoryMeta";
+import { plainTextFromRichText, resolveMemoryNodeTitle } from "./readShapeText";
+
+type TrackedNode = {
+  nodeId: string;
+  title: string;
+  content: string;
+  kind: string;
+  portalPalaceId: string | null;
+  portalRouteId: string | null;
+  portalNodeId: string | null;
+};
+
+type TrackedEdge = {
+  edgeKey: string;
+  edgeId: string | null;
+  sourceNodeId: string;
+  targetNodeId: string;
+  label: string;
+  castAb: string;
+  castCd: string;
+  castEf: string;
+  castGh: string;
+};
+
+export type SceneAnalyticsSnapshot = {
+  nodes: Map<string, TrackedNode>;
+  edges: Map<string, TrackedEdge>;
+};
+
+export type SceneAnalyticsDiff = {
+  eventType: AnalyticsEventType;
+  nodeId?: string;
+  payload: Record<string, unknown>;
+};
+
+function trackedEdgeKey(meta: MemoryPalaceMeta) {
+  return meta.mpEdgeId ?? meta.mpObjectId ?? `${meta.mpSourceNodeId ?? "unknown"}->${meta.mpTargetNodeId ?? "unknown"}`;
+}
+
+export function captureSceneAnalyticsSnapshot(editor: Editor): SceneAnalyticsSnapshot {
+  const nodes = new Map<string, TrackedNode>();
+  const edges = new Map<string, TrackedEdge>();
+
+  for (const shapeId of editor.getCurrentPageShapeIds()) {
+    const shape = editor.getShape(shapeId);
+    if (!shape) continue;
+    const meta = (shape.meta ?? {}) as MemoryPalaceMeta;
+
+    if (shape.type === "geo" && meta.mpNodeId) {
+      nodes.set(meta.mpNodeId, {
+        nodeId: meta.mpNodeId,
+        title: resolveMemoryNodeTitle(shape),
+        content: meta.mpContent ?? "",
+        kind: meta.mpNodeKind ?? "memory",
+        portalPalaceId: meta.mpPortalPalaceId ?? null,
+        portalRouteId: meta.mpPortalRouteId ?? null,
+        portalNodeId: meta.mpPortalNodeId ?? null,
+      });
+      continue;
+    }
+
+    if (shape.type !== "arrow" || !meta.mpSourceNodeId || !meta.mpTargetNodeId) continue;
+    const edgeKey = trackedEdgeKey(meta);
+    edges.set(edgeKey, {
+      edgeKey,
+      edgeId: meta.mpEdgeId ?? null,
+      sourceNodeId: meta.mpSourceNodeId,
+      targetNodeId: meta.mpTargetNodeId,
+      label: plainTextFromRichText(shape.props?.richText),
+      castAb: meta.castAb ?? "",
+      castCd: meta.castCd ?? "",
+      castEf: meta.castEf ?? "",
+      castGh: meta.castGh ?? "",
+    });
+  }
+
+  return { nodes, edges };
+}
+
+function changedFields(previous: Record<string, unknown>, next: Record<string, unknown>) {
+  const fields = new Set<string>([...Object.keys(previous), ...Object.keys(next)]);
+  return [...fields].filter((field) => previous[field] !== next[field]);
+}
+
+export function diffSceneAnalyticsSnapshots(
+  previous: SceneAnalyticsSnapshot | null,
+  next: SceneAnalyticsSnapshot,
+): SceneAnalyticsDiff[] {
+  if (!previous) return [];
+  const events: SceneAnalyticsDiff[] = [];
+
+  for (const [nodeId, node] of next.nodes.entries()) {
+    const earlier = previous.nodes.get(nodeId);
+    if (!earlier) {
+      events.push({
+        eventType: "node_created",
+        nodeId,
+        payload: {
+          title: node.title,
+          kind: node.kind,
+          portalPalaceId: node.portalPalaceId,
+          portalRouteId: node.portalRouteId,
+          portalNodeId: node.portalNodeId,
+        },
+      });
+      continue;
+    }
+    const fields = changedFields(earlier, node);
+    if (fields.length === 0) continue;
+    events.push({
+      eventType: "node_updated",
+      nodeId,
+      payload: {
+        title: node.title,
+        kind: node.kind,
+        changedFields: fields,
+      },
+    });
+  }
+
+  for (const [edgeKey, edge] of next.edges.entries()) {
+    const earlier = previous.edges.get(edgeKey);
+    if (!earlier) {
+      events.push({
+        eventType: "edge_created",
+        nodeId: edge.sourceNodeId,
+        payload: {
+          edgeId: edge.edgeId,
+          sourceNodeId: edge.sourceNodeId,
+          targetNodeId: edge.targetNodeId,
+          label: edge.label,
+          castAb: edge.castAb,
+          castCd: edge.castCd,
+          castEf: edge.castEf,
+          castGh: edge.castGh,
+        },
+      });
+      continue;
+    }
+    const fields = changedFields(earlier, edge);
+    if (fields.length === 0) continue;
+    events.push({
+      eventType: "edge_updated",
+      nodeId: edge.sourceNodeId,
+      payload: {
+        edgeId: edge.edgeId,
+        sourceNodeId: edge.sourceNodeId,
+        targetNodeId: edge.targetNodeId,
+        label: edge.label,
+        castAb: edge.castAb,
+        castCd: edge.castCd,
+        castEf: edge.castEf,
+        castGh: edge.castGh,
+        changedFields: fields,
+      },
+    });
+  }
+
+  return events;
+}

--- a/src/components/AnalyticsPanel.tsx
+++ b/src/components/AnalyticsPanel.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useMemo, type ReactNode } from "react";
+import { Activity, BarChart3, Brain, Clock3, ShieldCheck } from "lucide-react";
+import type { AnalyticsEvent } from "../domain/entities/types";
+import {
+  humanizeAnalyticsEventType,
+  parseAnalyticsPayload,
+  summarizeAnalytics,
+} from "../domain/services/analyticsService";
+import { usePalaceStore } from "../store/palaceStore";
+
+function formatEventDetail(event: AnalyticsEvent) {
+  const payload = parseAnalyticsPayload(event);
+  if (event.eventType === "walk_recall_rated") {
+    const rating = typeof payload.rating === "string" ? payload.rating : "unrated";
+    const latency = typeof payload.timeToRevealMs === "number" ? `${payload.timeToRevealMs} ms` : "no timer";
+    return `${rating} • ${latency}`;
+  }
+  if (event.eventType === "node_created" || event.eventType === "node_updated") {
+    return typeof payload.title === "string" && payload.title.trim() ? payload.title : "memory node";
+  }
+  if (event.eventType === "edge_created" || event.eventType === "edge_updated") {
+    return typeof payload.label === "string" && payload.label.trim() ? payload.label : "CAST edge";
+  }
+  if (event.eventType === "route_created") {
+    return typeof payload.name === "string" && payload.name.trim() ? payload.name : "route";
+  }
+  if (event.eventType === "system_run_materialized") {
+    return typeof payload.pipelineTitle === "string" ? payload.pipelineTitle : "theSystem run";
+  }
+  return typeof payload.source === "string" ? payload.source : "local event";
+}
+
+function StatCard({
+  icon,
+  label,
+  value,
+  tone = "zinc",
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  tone?: "zinc" | "violet" | "emerald";
+}) {
+  const toneClass =
+    tone === "violet"
+      ? "border-violet-800/60 bg-violet-950/30"
+      : tone === "emerald"
+        ? "border-emerald-800/60 bg-emerald-950/30"
+        : "border-zinc-800 bg-zinc-900/40";
+
+  return (
+    <div className={`rounded-md border p-3 ${toneClass}`}>
+      <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-2 text-2xl font-semibold text-zinc-100">{value}</div>
+    </div>
+  );
+}
+
+export function AnalyticsPanel() {
+  const currentPalace = usePalaceStore((s) => s.currentPalace);
+  const analyticsEvents = usePalaceStore((s) => s.analyticsEvents);
+  const analyticsLoaded = usePalaceStore((s) => s.analyticsLoaded);
+  const loadAnalyticsEvents = usePalaceStore((s) => s.loadAnalyticsEvents);
+
+  useEffect(() => {
+    if (!analyticsLoaded) {
+      void loadAnalyticsEvents();
+    }
+  }, [analyticsLoaded, loadAnalyticsEvents]);
+
+  const allSummary = useMemo(() => summarizeAnalytics(analyticsEvents), [analyticsEvents]);
+  const palaceEvents = useMemo(() => {
+    if (!currentPalace) return [] as AnalyticsEvent[];
+    return analyticsEvents.filter((event) => event.palaceId === currentPalace.id);
+  }, [analyticsEvents, currentPalace]);
+  const palaceSummary = useMemo(() => summarizeAnalytics(palaceEvents), [palaceEvents]);
+  const recentEvents = useMemo(() => analyticsEvents.slice(0, 12), [analyticsEvents]);
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="border-b border-zinc-800 pb-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-violet-200">
+          <BarChart3 className="h-4 w-4" />
+          Analytics
+        </div>
+        <p className="mt-1 max-w-3xl text-xs leading-5 text-zinc-400">
+          Local-first telemetry for encoding and retrieval. Events stay on this device by default, are stored in SQLite
+          in the app and `localStorage` in the browser fallback, and can be inspected here.
+        </p>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto py-3">
+        <div className="grid gap-3 md:grid-cols-3">
+          <StatCard icon={<Activity className="h-3.5 w-3.5" />} label="Total events" value={String(allSummary.totalEvents)} />
+          <StatCard
+            icon={<Brain className="h-3.5 w-3.5" />}
+            label="Review ratings"
+            value={String(allSummary.countsByType.walk_recall_rated ?? 0)}
+            tone="violet"
+          />
+          <StatCard
+            icon={<Clock3 className="h-3.5 w-3.5" />}
+            label="Avg reveal time"
+            value={allSummary.averageRecallLatencyMs === null ? "n/a" : `${allSummary.averageRecallLatencyMs} ms`}
+            tone="emerald"
+          />
+        </div>
+
+        <div className="mt-3 grid gap-3 lg:grid-cols-[1.2fr_1fr]">
+          <section className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-zinc-100">
+              <ShieldCheck className="h-4 w-4 text-violet-300" />
+              What is tracked
+            </div>
+            <ul className="mt-3 space-y-1 text-sm text-zinc-300">
+              <li>- Palace lifecycle: created, opened, draft-saved, checkpoint-saved.</li>
+              <li>- Graph work: node create/update, edge create/update, route create, locus add/update.</li>
+              <li>- Review flow: walk start, step changes, recall ratings, walk close.</li>
+              <li>- theSystem runs: pipeline materialization into graph structure.</li>
+            </ul>
+          </section>
+
+          <section className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="text-sm font-medium text-zinc-100">Current session</div>
+            <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+              <div className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
+                <div className="text-zinc-500">Nodes</div>
+                <div className="font-semibold text-zinc-100">
+                  {(allSummary.currentSessionCounts.node_created ?? 0) + (allSummary.currentSessionCounts.node_updated ?? 0)}
+                </div>
+              </div>
+              <div className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
+                <div className="text-zinc-500">Edges</div>
+                <div className="font-semibold text-zinc-100">
+                  {(allSummary.currentSessionCounts.edge_created ?? 0) + (allSummary.currentSessionCounts.edge_updated ?? 0)}
+                </div>
+              </div>
+              <div className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
+                <div className="text-zinc-500">Routes</div>
+                <div className="font-semibold text-zinc-100">{allSummary.currentSessionCounts.route_created ?? 0}</div>
+              </div>
+              <div className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
+                <div className="text-zinc-500">Review actions</div>
+                <div className="font-semibold text-zinc-100">
+                  {(allSummary.currentSessionCounts.walk_stepped ?? 0) + (allSummary.currentSessionCounts.walk_recall_rated ?? 0)}
+                </div>
+              </div>
+            </div>
+            <div className="mt-3 text-xs text-zinc-500">
+              Session id: {allSummary.currentSessionId ? allSummary.currentSessionId.slice(0, 8) : "not started"}
+            </div>
+          </section>
+        </div>
+
+        <div className="mt-3 grid gap-3 lg:grid-cols-[1fr_1.15fr]">
+          <section className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="text-sm font-medium text-zinc-100">Current palace snapshot</div>
+            <div className="mt-3 grid grid-cols-2 gap-2 text-sm">
+              <div className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
+                <div className="text-zinc-500">Nodes created</div>
+                <div className="font-semibold text-zinc-100">{palaceSummary.countsByType.node_created ?? 0}</div>
+              </div>
+              <div className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
+                <div className="text-zinc-500">Edges created</div>
+                <div className="font-semibold text-zinc-100">{palaceSummary.countsByType.edge_created ?? 0}</div>
+              </div>
+              <div className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
+                <div className="text-zinc-500">Recall again</div>
+                <div className="font-semibold text-zinc-100">{palaceSummary.recallRatings.again}</div>
+              </div>
+              <div className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
+                <div className="text-zinc-500">Recall easy</div>
+                <div className="font-semibold text-zinc-100">{palaceSummary.recallRatings.easy}</div>
+              </div>
+            </div>
+            <div className="mt-3 text-xs text-zinc-500">
+              Palace: {currentPalace ? currentPalace.name : "Open a palace to see palace-scoped analytics."}
+            </div>
+          </section>
+
+          <section className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="text-sm font-medium text-zinc-100">Recent events</div>
+            <div className="mt-3 space-y-2">
+              {recentEvents.length === 0 ? (
+                <div className="rounded border border-dashed border-zinc-800 bg-zinc-950/40 px-3 py-4 text-sm text-zinc-500">
+                  No analytics events yet.
+                </div>
+              ) : (
+                recentEvents.map((event) => (
+                  <div key={event.id} className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
+                    <div className="flex items-center justify-between gap-3 text-sm">
+                      <div className="font-medium capitalize text-zinc-100">{humanizeAnalyticsEventType(event.eventType)}</div>
+                      <div className="text-[11px] text-zinc-500">{new Date(event.createdAt).toLocaleString()}</div>
+                    </div>
+                    <div className="mt-1 text-xs text-zinc-400">{formatEventDetail(event)}</div>
+                  </div>
+                ))
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/OnboardingPanel.tsx
+++ b/src/components/OnboardingPanel.tsx
@@ -8,6 +8,7 @@ import { usePalaceStore } from "../store/palaceStore";
 import { Button } from "./ui/button";
 import type { MemoryPalaceMeta } from "../canvas/memoryMeta";
 import type { Locus, MemoryRoute } from "../domain/entities/types";
+import { AnalyticsPanel } from "./AnalyticsPanel";
 import { TheSystemWorkbench } from "./TheSystemWorkbench";
 
 type Lesson = {
@@ -115,7 +116,7 @@ export function OnboardingPanel({ open, onClose }: Props) {
   const setToolMode = usePalaceStore((s) => s.setToolMode);
 
   const [lessonId, setLessonId] = useState<string>(LESSONS[0].id);
-  const [panelTab, setPanelTab] = useState<"guides" | "system">("guides");
+  const [panelTab, setPanelTab] = useState<"guides" | "system" | "analytics">("guides");
   const [loadingExampleId, setLoadingExampleId] = useState<string | null>(null);
   const [, bumpSceneRevision] = useReducer((v: number) => v + 1, 0);
 
@@ -402,7 +403,7 @@ export function OnboardingPanel({ open, onClose }: Props) {
   return (
     <aside
       className={`flex h-full shrink-0 flex-col border-l border-zinc-800 bg-zinc-950 ${
-        panelTab === "system" ? "w-[min(720px,68vw)]" : "w-[360px]"
+        panelTab === "guides" ? "w-[360px]" : "w-[min(760px,72vw)]"
       }`}
     >
       <div className="flex items-center justify-between border-b border-zinc-800 px-3 py-2">
@@ -432,6 +433,14 @@ export function OnboardingPanel({ open, onClose }: Props) {
             onClick={() => setPanelTab("system")}
           >
             theSystem
+          </Button>
+          <Button
+            size="sm"
+            type="button"
+            variant={panelTab === "analytics" ? "default" : "secondary"}
+            onClick={() => setPanelTab("analytics")}
+          >
+            Analytics
           </Button>
         </div>
       </div>
@@ -525,9 +534,13 @@ export function OnboardingPanel({ open, onClose }: Props) {
             </Button>
           </div>
         </>
-      ) : (
+      ) : panelTab === "system" ? (
         <div className="min-h-0 flex-1 p-3">
           <TheSystemWorkbench />
+        </div>
+      ) : (
+        <div className="min-h-0 flex-1 p-3">
+          <AnalyticsPanel />
         </div>
       )}
     </aside>

--- a/src/components/TheSystemWorkbench.tsx
+++ b/src/components/TheSystemWorkbench.tsx
@@ -19,6 +19,7 @@ export function TheSystemWorkbench() {
   const editorRef = usePalaceStore((s) => s.editorRef);
   const selectedShapeId = usePalaceStore((s) => s.selectedShapeId);
   const replaceRoutesAndLoci = usePalaceStore((s) => s.replaceRoutesAndLoci);
+  const recordAnalyticsEvent = usePalaceStore((s) => s.recordAnalyticsEvent);
 
   const [tab, setTab] = useState<WorkbenchTab>("pipelines");
   const [selectedPipelineId, setSelectedPipelineId] = useState<string>(THE_SYSTEM_PIPELINES[0]?.id ?? "");
@@ -86,6 +87,21 @@ export function TheSystemWorkbench() {
       replaceRoutesAndLoci([...state.routes, result.route], [...state.loci, ...result.loci]);
       usePalaceStore.setState({
         selectedShapeId: result.overviewShapeId,
+      });
+      void recordAnalyticsEvent({
+        eventType: "system_run_materialized",
+        eventGroup: "system",
+        palaceId: currentPalace.id,
+        routeId: result.route.id,
+        nodeId: result.overviewNodeId,
+        payload: {
+          pipelineId: template.id,
+          pipelineTitle: template.title,
+          sessionTitle: sessionTitle.trim() || null,
+          focus: focus.trim() || null,
+          createdNodeCount: result.createdNodeCount,
+          selectedShapeId: selectedNodeContext?.shapeId ?? null,
+        },
       });
 
       editorRef.setSelectedShapes([result.overviewShapeId as TLShapeId]);

--- a/src/components/WalkModeBar.tsx
+++ b/src/components/WalkModeBar.tsx
@@ -12,6 +12,7 @@ type Props = {
 export function WalkModeBar({ onHoverHintChange }: Props) {
   const walkOpen = usePalaceStore((s) => s.walkOpen);
   const setWalkOpen = usePalaceStore((s) => s.setWalkOpen);
+  const rateWalkRecall = usePalaceStore((s) => s.rateWalkRecall);
   const walkNext = usePalaceStore((s) => s.walkNext);
   const walkPrev = usePalaceStore((s) => s.walkPrev);
   const routes = usePalaceStore((s) => s.routes);
@@ -83,7 +84,53 @@ export function WalkModeBar({ onHoverHintChange }: Props) {
               <div className="h-full bg-violet-400 transition-all" style={{ width: `${progressPct}%` }} />
             </div>
           </div>
-          <div className="ml-auto flex shrink-0 items-center gap-1 border-l border-zinc-800/80 pl-2">
+          <div className="ml-auto flex shrink-0 items-center gap-2 border-l border-zinc-800/80 pl-2">
+            <div className="hidden items-center gap-1 lg:flex">
+              <Button
+                size="sm"
+                variant="outline"
+                type="button"
+                className="border-rose-800/70 bg-rose-950/30 text-rose-100 hover:bg-rose-900/40"
+                onClick={() => rateWalkRecall("again")}
+                onMouseEnter={() => onHoverHintChange?.("Rate recall as Again. Analytics stays local and tracks weak spots.")}
+                onMouseLeave={() => onHoverHintChange?.(null)}
+              >
+                Again
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                type="button"
+                className="border-amber-800/70 bg-amber-950/30 text-amber-100 hover:bg-amber-900/40"
+                onClick={() => rateWalkRecall("hard")}
+                onMouseEnter={() => onHoverHintChange?.("Rate recall as Hard. This marks effortful retrieval without full failure.")}
+                onMouseLeave={() => onHoverHintChange?.(null)}
+              >
+                Hard
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                type="button"
+                className="border-emerald-800/70 bg-emerald-950/30 text-emerald-100 hover:bg-emerald-900/40"
+                onClick={() => rateWalkRecall("good")}
+                onMouseEnter={() => onHoverHintChange?.("Rate recall as Good. Useful for review timing and strength analytics.")}
+                onMouseLeave={() => onHoverHintChange?.(null)}
+              >
+                Good
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                type="button"
+                className="border-cyan-800/70 bg-cyan-950/30 text-cyan-100 hover:bg-cyan-900/40"
+                onClick={() => rateWalkRecall("easy")}
+                onMouseEnter={() => onHoverHintChange?.("Rate recall as Easy. Fast, stable recall should trend toward this.")}
+                onMouseLeave={() => onHoverHintChange?.(null)}
+              >
+                Easy
+              </Button>
+            </div>
             <Button
               size="sm"
               variant="ghost"

--- a/src/domain/entities/types.ts
+++ b/src/domain/entities/types.ts
@@ -65,6 +65,40 @@ export interface Locus {
   label: string;
 }
 
+export type AnalyticsEventGroup = "palace" | "graph" | "review" | "system";
+
+export type AnalyticsEventType =
+  | "palace_created"
+  | "palace_opened"
+  | "palace_saved"
+  | "draft_saved"
+  | "node_created"
+  | "node_updated"
+  | "edge_created"
+  | "edge_updated"
+  | "route_created"
+  | "locus_added"
+  | "locus_updated"
+  | "walk_started"
+  | "walk_stepped"
+  | "walk_recall_rated"
+  | "walk_closed"
+  | "system_run_materialized";
+
+export type RecallRating = "again" | "hard" | "good" | "easy";
+
+export interface AnalyticsEvent {
+  id: string;
+  sessionId?: string | null;
+  palaceId?: string | null;
+  routeId?: string | null;
+  nodeId?: string | null;
+  eventType: AnalyticsEventType;
+  eventGroup: AnalyticsEventGroup;
+  createdAt: string;
+  payloadJson: string;
+}
+
 export interface PalaceSnapshot {
   palace: Palace;
   canvasObjects: CanvasObject[];

--- a/src/domain/repositories/palaceRepository.ts
+++ b/src/domain/repositories/palaceRepository.ts
@@ -1,10 +1,12 @@
-import type { Palace, PalaceSnapshot } from "../entities/types";
+import type { AnalyticsEvent, Palace, PalaceSnapshot } from "../entities/types";
 
 export interface PalaceRepository {
   listPalaces(): Promise<Palace[]>;
   createPalace(name: string, atlasPath?: string | null): Promise<Palace>;
   loadPalace(palaceId: string): Promise<PalaceSnapshot | null>;
   savePalace(snapshot: PalaceSnapshot): Promise<void>;
+  listAnalyticsEvents(limit?: number): Promise<AnalyticsEvent[]>;
+  appendAnalyticsEvents(events: AnalyticsEvent[]): Promise<void>;
   exportJson(snapshot: PalaceSnapshot): Promise<string>;
   importJson(json: string): Promise<PalaceSnapshot>;
 }

--- a/src/domain/services/analyticsService.test.ts
+++ b/src/domain/services/analyticsService.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { createAnalyticsEvent, parseAnalyticsPayload, summarizeAnalytics } from "./analyticsService";
+
+describe("analyticsService", () => {
+  it("serializes payloads and summarizes session activity", () => {
+    const events = [
+      createAnalyticsEvent({
+        eventType: "palace_opened",
+        eventGroup: "palace",
+        sessionId: "session-1",
+        palaceId: "palace-a",
+        createdAt: "2026-04-26T09:00:00.000Z",
+      }),
+      createAnalyticsEvent({
+        eventType: "node_created",
+        eventGroup: "graph",
+        sessionId: "session-1",
+        palaceId: "palace-a",
+        nodeId: "node-1",
+        createdAt: "2026-04-26T09:01:00.000Z",
+        payload: { title: "Gateway" },
+      }),
+      createAnalyticsEvent({
+        eventType: "walk_recall_rated",
+        eventGroup: "review",
+        sessionId: "session-1",
+        palaceId: "palace-a",
+        routeId: "route-1",
+        nodeId: "node-1",
+        createdAt: "2026-04-26T09:02:00.000Z",
+        payload: { rating: "good", timeToRevealMs: 1800 },
+      }),
+      createAnalyticsEvent({
+        eventType: "palace_opened",
+        eventGroup: "palace",
+        sessionId: "session-2",
+        palaceId: "palace-b",
+        createdAt: "2026-04-26T10:00:00.000Z",
+      }),
+      createAnalyticsEvent({
+        eventType: "walk_recall_rated",
+        eventGroup: "review",
+        sessionId: "session-2",
+        palaceId: "palace-b",
+        routeId: "route-2",
+        nodeId: "node-2",
+        createdAt: "2026-04-26T10:02:00.000Z",
+        payload: { rating: "easy", timeToRevealMs: 900 },
+      }),
+    ];
+
+    const summary = summarizeAnalytics(events);
+
+    expect(summary.totalEvents).toBe(5);
+    expect(summary.currentSessionId).toBe("session-2");
+    expect(summary.countsByGroup.review).toBe(2);
+    expect(summary.countsByType.walk_recall_rated).toBe(2);
+    expect(summary.currentSessionCounts.walk_recall_rated).toBe(1);
+    expect(summary.recallRatings.good).toBe(1);
+    expect(summary.recallRatings.easy).toBe(1);
+    expect(summary.averageRecallLatencyMs).toBe(1350);
+    expect(parseAnalyticsPayload(events[1]).title).toBe("Gateway");
+  });
+
+  it("ignores malformed payload json", () => {
+    const summary = summarizeAnalytics([
+      {
+        id: "broken",
+        sessionId: "session-1",
+        palaceId: "palace-a",
+        routeId: "route-1",
+        nodeId: "node-1",
+        eventType: "walk_recall_rated",
+        eventGroup: "review",
+        createdAt: "2026-04-26T09:02:00.000Z",
+        payloadJson: "{not-json",
+      },
+    ]);
+
+    expect(summary.recallRatings.good).toBe(0);
+    expect(summary.averageRecallLatencyMs).toBeNull();
+  });
+});

--- a/src/domain/services/analyticsService.ts
+++ b/src/domain/services/analyticsService.ts
@@ -1,0 +1,111 @@
+import type { AnalyticsEvent, AnalyticsEventGroup, AnalyticsEventType, RecallRating } from "../entities/types";
+
+export type AnalyticsPayload = Record<string, unknown>;
+
+export type AnalyticsSummary = {
+  totalEvents: number;
+  countsByType: Partial<Record<AnalyticsEventType, number>>;
+  countsByGroup: Partial<Record<AnalyticsEventGroup, number>>;
+  currentSessionId: string | null;
+  currentSessionCounts: Partial<Record<AnalyticsEventType, number>>;
+  recallRatings: Record<RecallRating, number>;
+  averageRecallLatencyMs: number | null;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export function serializeAnalyticsPayload(payload?: AnalyticsPayload) {
+  return JSON.stringify(payload ?? {});
+}
+
+export function parseAnalyticsPayload(eventOrJson: AnalyticsEvent | string | null | undefined): AnalyticsPayload {
+  const raw = typeof eventOrJson === "string" ? eventOrJson : eventOrJson?.payloadJson;
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return isRecord(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function createAnalyticsEvent(input: {
+  eventType: AnalyticsEventType;
+  eventGroup: AnalyticsEventGroup;
+  sessionId?: string | null;
+  palaceId?: string | null;
+  routeId?: string | null;
+  nodeId?: string | null;
+  createdAt?: string;
+  payload?: AnalyticsPayload;
+}): AnalyticsEvent {
+  return {
+    id: crypto.randomUUID(),
+    sessionId: input.sessionId ?? null,
+    palaceId: input.palaceId ?? null,
+    routeId: input.routeId ?? null,
+    nodeId: input.nodeId ?? null,
+    eventType: input.eventType,
+    eventGroup: input.eventGroup,
+    createdAt: input.createdAt ?? new Date().toISOString(),
+    payloadJson: serializeAnalyticsPayload(input.payload),
+  };
+}
+
+function increment<T extends string>(counts: Partial<Record<T, number>>, key: T) {
+  counts[key] = (counts[key] ?? 0) + 1;
+}
+
+export function humanizeAnalyticsEventType(eventType: AnalyticsEventType) {
+  return eventType.replace(/_/g, " ");
+}
+
+export function summarizeAnalytics(events: AnalyticsEvent[]): AnalyticsSummary {
+  const sorted = events.slice().sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  const countsByType: Partial<Record<AnalyticsEventType, number>> = {};
+  const countsByGroup: Partial<Record<AnalyticsEventGroup, number>> = {};
+  const recallRatings: Record<RecallRating, number> = {
+    again: 0,
+    hard: 0,
+    good: 0,
+    easy: 0,
+  };
+  const currentSessionId = sorted.find((event) => event.sessionId)?.sessionId ?? null;
+  const currentSessionCounts: Partial<Record<AnalyticsEventType, number>> = {};
+
+  let recallLatencyTotal = 0;
+  let recallLatencyCount = 0;
+
+  for (const event of sorted) {
+    increment(countsByType, event.eventType);
+    increment(countsByGroup, event.eventGroup);
+
+    if (currentSessionId && event.sessionId === currentSessionId) {
+      increment(currentSessionCounts, event.eventType);
+    }
+
+    if (event.eventType !== "walk_recall_rated") continue;
+    const payload = parseAnalyticsPayload(event);
+    const rating = payload.rating;
+    if (rating === "again" || rating === "hard" || rating === "good" || rating === "easy") {
+      recallRatings[rating] += 1;
+    }
+    const latencyMs = payload.timeToRevealMs;
+    if (typeof latencyMs === "number" && Number.isFinite(latencyMs) && latencyMs >= 0) {
+      recallLatencyTotal += latencyMs;
+      recallLatencyCount += 1;
+    }
+  }
+
+  return {
+    totalEvents: sorted.length,
+    countsByType,
+    countsByGroup,
+    currentSessionId,
+    currentSessionCounts,
+    recallRatings,
+    averageRecallLatencyMs: recallLatencyCount > 0 ? Math.round(recallLatencyTotal / recallLatencyCount) : null,
+  };
+}

--- a/src/infrastructure/memory/inMemoryPalaceRepository.test.ts
+++ b/src/infrastructure/memory/inMemoryPalaceRepository.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { createInMemoryPalaceRepository } from "./inMemoryPalaceRepository";
+import { createAnalyticsEvent } from "../../domain/services/analyticsService";
 
 describe("createInMemoryPalaceRepository", () => {
   it("creates, loads, and saves a palace snapshot", async () => {
@@ -48,5 +49,27 @@ describe("createInMemoryPalaceRepository", () => {
     const json = await r.exportJson(snap);
     const imported = await r.importJson(json);
     expect(imported.palace.id).toBe(p.id);
+  });
+
+  it("persists analytics events in browser storage fallback", async () => {
+    window.localStorage.clear();
+    const first = createInMemoryPalaceRepository();
+    await first.appendAnalyticsEvents([
+      createAnalyticsEvent({
+        eventType: "palace_opened",
+        eventGroup: "palace",
+        sessionId: "session-1",
+        palaceId: "palace-1",
+        createdAt: "2026-04-26T09:00:00.000Z",
+      }),
+    ]);
+
+    const second = createInMemoryPalaceRepository();
+    const events = await second.listAnalyticsEvents();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]?.sessionId).toBe("session-1");
+    expect(events[0]?.eventType).toBe("palace_opened");
+    window.localStorage.clear();
   });
 });

--- a/src/infrastructure/memory/inMemoryPalaceRepository.ts
+++ b/src/infrastructure/memory/inMemoryPalaceRepository.ts
@@ -1,9 +1,29 @@
 import type { PalaceRepository } from "../../domain/repositories/palaceRepository";
-import type { Palace, PalaceSnapshot } from "../../domain/entities/types";
+import type { AnalyticsEvent, Palace, PalaceSnapshot } from "../../domain/entities/types";
+
+const ANALYTICS_STORAGE_KEY = "memory-palace:analytics-events";
+
+function readStoredAnalyticsEvents() {
+  if (typeof window === "undefined") return [] as AnalyticsEvent[];
+  try {
+    const raw = window.localStorage.getItem(ANALYTICS_STORAGE_KEY);
+    if (!raw) return [] as AnalyticsEvent[];
+    const parsed = JSON.parse(raw) as AnalyticsEvent[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [] as AnalyticsEvent[];
+  }
+}
+
+function writeStoredAnalyticsEvents(events: AnalyticsEvent[]) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(ANALYTICS_STORAGE_KEY, JSON.stringify(events));
+}
 
 /** Browser-only fallback when Tauri APIs are unavailable (e.g. `vite` without `tauri dev`). */
 export function createInMemoryPalaceRepository(): PalaceRepository {
   const palaces = new Map<string, PalaceSnapshot>();
+  let analyticsEvents = readStoredAnalyticsEvents();
 
   return {
     async listPalaces() {
@@ -29,6 +49,16 @@ export function createInMemoryPalaceRepository(): PalaceRepository {
     },
     async savePalace(snapshot: PalaceSnapshot) {
       palaces.set(snapshot.palace.id, JSON.parse(JSON.stringify(snapshot)) as PalaceSnapshot);
+    },
+    async listAnalyticsEvents(limit) {
+      const list = analyticsEvents
+        .slice()
+        .sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+      return typeof limit === "number" ? list.slice(0, limit) : list;
+    },
+    async appendAnalyticsEvents(events) {
+      analyticsEvents = [...analyticsEvents, ...(JSON.parse(JSON.stringify(events)) as AnalyticsEvent[])];
+      writeStoredAnalyticsEvents(analyticsEvents);
     },
     async exportJson(snapshot: PalaceSnapshot) {
       return JSON.stringify({ version: 1, snapshot }, null, 2);

--- a/src/infrastructure/tauri/palaceRepositoryTauri.ts
+++ b/src/infrastructure/tauri/palaceRepositoryTauri.ts
@@ -1,6 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { PalaceRepository } from "../../domain/repositories/palaceRepository";
-import type { Palace, PalaceSnapshot } from "../../domain/entities/types";
+import type { AnalyticsEvent, Palace, PalaceSnapshot } from "../../domain/entities/types";
 
 /** Raw JSON matches Rust serde camelCase + `type` for canvas rows. */
 type InvokePalaceSnapshot = {
@@ -47,6 +47,8 @@ type InvokePalaceSnapshot = {
     label?: string;
   }>;
 };
+
+type InvokeAnalyticsEvent = AnalyticsEvent;
 
 function fromInvoke(raw: InvokePalaceSnapshot): PalaceSnapshot {
   return {
@@ -163,6 +165,12 @@ export function createPalaceRepositoryTauri(): PalaceRepository {
     },
     async savePalace(snapshot: PalaceSnapshot) {
       await invoke("palace_save", { snapshot: toInvoke(snapshot) });
+    },
+    async listAnalyticsEvents(limit) {
+      return invoke<InvokeAnalyticsEvent[]>("analytics_list", { limit });
+    },
+    async appendAnalyticsEvents(events) {
+      await invoke("analytics_append", { events });
     },
     async exportJson(snapshot: PalaceSnapshot) {
       return invoke<string>("palace_export_json", { snapshot: toInvoke(snapshot) });

--- a/src/store/palaceStore.ts
+++ b/src/store/palaceStore.ts
@@ -1,7 +1,19 @@
 import { create } from "zustand";
 import type { Editor } from "@tldraw/editor";
-import type { Locus, MemoryEdge, MemoryNode, MemoryRoute, Palace, PalaceSnapshot } from "../domain/entities/types";
+import type {
+  AnalyticsEvent,
+  AnalyticsEventGroup,
+  AnalyticsEventType,
+  Locus,
+  MemoryEdge,
+  MemoryNode,
+  MemoryRoute,
+  Palace,
+  PalaceSnapshot,
+  RecallRating,
+} from "../domain/entities/types";
 import { buildPalaceSnapshot } from "../canvas/buildPalaceSnapshot";
+import { createAnalyticsEvent } from "../domain/services/analyticsService";
 import { getPalaceRepository } from "../infrastructure/palaceRepositoryProvider";
 import { clearPalaceDraft, loadPalaceDraft, savePalaceDraft } from "../infrastructure/draft/palaceDraftStore";
 import {
@@ -18,6 +30,15 @@ export type ToolMode = "select" | "connect" | "route";
 export type PalacePersistenceState = "clean" | "dirty" | "draft";
 
 type ConnectState = { fromShapeId: string | null };
+type RecordAnalyticsInput = {
+  eventType: AnalyticsEventType;
+  eventGroup: AnalyticsEventGroup;
+  sessionId?: string | null;
+  palaceId?: string | null;
+  routeId?: string | null;
+  nodeId?: string | null;
+  payload?: Record<string, unknown>;
+};
 
 export type PalaceStore = {
   palaces: Palace[];
@@ -26,6 +47,9 @@ export type PalaceStore = {
   edges: MemoryEdge[];
   routes: MemoryRoute[];
   loci: Locus[];
+  analyticsEvents: AnalyticsEvent[];
+  analyticsSessionId: string | null;
+  analyticsLoaded: boolean;
   editorRef: Editor | null;
   selectedShapeId: string | null;
   toolMode: ToolMode;
@@ -33,11 +57,14 @@ export type PalaceStore = {
   walkOpen: boolean;
   walkRouteId: string | null;
   walkIndex: number;
+  walkStepEnteredAt: string | null;
   persistenceState: PalacePersistenceState;
   lastDraftSavedAt: string | null;
   draftRestored: boolean;
   pendingCast: null | { fromShapeId: string; toShapeId: string; sourceNodeId: string; targetNodeId: string };
   loadPalaces: () => Promise<void>;
+  loadAnalyticsEvents: (limit?: number) => Promise<void>;
+  recordAnalyticsEvent: (input: RecordAnalyticsInput) => Promise<AnalyticsEvent>;
   openPalace: (id: string) => Promise<void>;
   createPalace: (name: string, atlasPath?: string | null) => Promise<void>;
   saveCurrent: () => Promise<void>;
@@ -55,6 +82,7 @@ export type PalaceStore = {
   replaceRoutesAndLoci: (routes: MemoryRoute[], loci: Locus[]) => void;
   setWalkRoute: (routeId: string | null) => void;
   setWalkOpen: (v: boolean) => void;
+  rateWalkRecall: (rating: RecallRating) => void;
   walkNext: () => void;
   walkPrev: () => void;
   currentWalkNodeId: () => string | null;
@@ -80,10 +108,92 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
     draftTimer = null;
   };
 
+  const mergeAnalyticsEvents = (current: AnalyticsEvent[], next: AnalyticsEvent[]) => {
+    const byId = new Map<string, AnalyticsEvent>();
+    for (const event of current) byId.set(event.id, event);
+    for (const event of next) byId.set(event.id, event);
+    return [...byId.values()].sort((a, b) => b.createdAt.localeCompare(a.createdAt));
+  };
+
   const buildCurrentSnapshot = () => {
     const { editorRef, currentPalace, routes, loci } = get();
     if (!editorRef || !currentPalace) return null;
     return buildPalaceSnapshot(editorRef, currentPalace, routes, loci);
+  };
+
+  const appendAnalyticsEvents = async (events: AnalyticsEvent[]) => {
+    if (events.length === 0) return;
+    await repo.appendAnalyticsEvents(events);
+    set((state) => ({
+      analyticsEvents: mergeAnalyticsEvents(state.analyticsEvents, events),
+      analyticsLoaded: true,
+    }));
+  };
+
+  const recordAnalytics = async (input: RecordAnalyticsInput) => {
+    const state = get();
+    const event = createAnalyticsEvent({
+      eventType: input.eventType,
+      eventGroup: input.eventGroup,
+      sessionId: "sessionId" in input ? input.sessionId ?? null : state.analyticsSessionId,
+      palaceId: "palaceId" in input ? input.palaceId ?? null : state.currentPalace?.id ?? null,
+      routeId: "routeId" in input ? input.routeId ?? null : null,
+      nodeId: "nodeId" in input ? input.nodeId ?? null : null,
+      payload: input.payload,
+    });
+    await appendAnalyticsEvents([event]);
+    return event;
+  };
+
+  const getWalkContext = () => {
+    const { loci, routes, walkRouteId, walkIndex, currentPalace } = get();
+    const routeId = walkRouteId ?? routes[0]?.id ?? null;
+    const route = routes.find((candidate) => candidate.id === routeId) ?? null;
+    if (!routeId) {
+      return {
+        palaceId: currentPalace?.id ?? null,
+        routeId: null,
+        routeName: null,
+        list: [] as Locus[],
+        locus: null,
+        nodeId: null,
+        count: 0,
+        stepIndex: 0,
+      };
+    }
+    const list = orderedLoci(loci.filter((locus) => locus.routeId === routeId));
+    const locus = locusAtOrderedIndex(list, walkIndex) ?? null;
+    return {
+      palaceId: currentPalace?.id ?? null,
+      routeId,
+      routeName: route?.name ?? null,
+      list,
+      locus,
+      nodeId: locus?.nodeId ?? null,
+      count: list.length,
+      stepIndex: walkIndex,
+    };
+  };
+
+  const noteWalkStepEntered = (direction: "open" | "next" | "prev" | "route_change") => {
+    const enteredAt = new Date().toISOString();
+    set({ walkStepEnteredAt: enteredAt });
+    const context = getWalkContext();
+    if (!context.routeId || !context.nodeId) return;
+    void recordAnalytics({
+      eventType: "walk_stepped",
+      eventGroup: "review",
+      palaceId: context.palaceId,
+      routeId: context.routeId,
+      nodeId: context.nodeId,
+      payload: {
+        direction,
+        stepIndex: context.stepIndex,
+        routeLength: context.count,
+        locusId: context.locus?.id ?? null,
+        routeName: context.routeName,
+      },
+    });
   };
 
   const persistDraftNow = () => {
@@ -95,9 +205,22 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       palaces: mergePalaceIntoList(state.palaces, snapshot.palace),
       nodes: snapshot.nodes,
       edges: snapshot.edges,
-      persistenceState: savedAt ? "draft" : state.persistenceState,
-      lastDraftSavedAt: savedAt ?? state.lastDraftSavedAt,
-    }));
+        persistenceState: savedAt ? "draft" : state.persistenceState,
+        lastDraftSavedAt: savedAt ?? state.lastDraftSavedAt,
+      }));
+      if (savedAt) {
+        void recordAnalytics({
+          eventType: "draft_saved",
+          eventGroup: "palace",
+          palaceId: snapshot.palace.id,
+          payload: {
+            savedAt,
+            nodeCount: snapshot.nodes.length,
+            edgeCount: snapshot.edges.length,
+            routeCount: snapshot.routes.length,
+          },
+        });
+      }
   };
 
   const scheduleDraftSave = () => {
@@ -119,6 +242,9 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
     edges: [],
     routes: [],
     loci: [],
+    analyticsEvents: [],
+    analyticsSessionId: null,
+    analyticsLoaded: false,
     editorRef: null,
     selectedShapeId: null,
     toolMode: "select",
@@ -126,6 +252,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
     walkOpen: false,
     walkRouteId: null,
     walkIndex: 0,
+    walkStepEnteredAt: null,
     persistenceState: "clean",
     lastDraftSavedAt: null,
     draftRestored: false,
@@ -139,11 +266,25 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       });
     },
 
+    async loadAnalyticsEvents(limit) {
+      const analyticsEvents = await repo.listAnalyticsEvents(limit);
+      set((state) => ({
+        analyticsEvents: mergeAnalyticsEvents(state.analyticsEvents, analyticsEvents),
+        analyticsLoaded: true,
+      }));
+    },
+
+    async recordAnalyticsEvent(input) {
+      return recordAnalytics(input);
+    },
+
     async openPalace(id: string) {
       await get().flushDraftSave();
       clearDraftTimer();
       const snap = await repo.loadPalace(id);
       if (!snap) return;
+      const sessionId = crypto.randomUUID();
+      set({ analyticsSessionId: sessionId });
       const draft = loadPalaceDraft(id);
       if (draft) {
         get().hydrateFromSnapshot(draft.snapshot, {
@@ -151,12 +292,24 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
           draftRestored: true,
           lastDraftSavedAt: draft.savedAt,
         });
-        return;
+      } else {
+        get().hydrateFromSnapshot(snap, {
+          persistenceState: "clean",
+          draftRestored: false,
+          lastDraftSavedAt: null,
+        });
       }
-      get().hydrateFromSnapshot(snap, {
-        persistenceState: "clean",
-        draftRestored: false,
-        lastDraftSavedAt: null,
+      await recordAnalytics({
+        eventType: "palace_opened",
+        eventGroup: "palace",
+        sessionId,
+        palaceId: id,
+        payload: {
+          source: draft ? "draft" : "saved",
+          nodeCount: (draft?.snapshot ?? snap).nodes.length,
+          edgeCount: (draft?.snapshot ?? snap).edges.length,
+          routeCount: (draft?.snapshot ?? snap).routes.length,
+        },
       });
     },
 
@@ -164,6 +317,16 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       await get().flushDraftSave();
       clearDraftTimer();
       const p = await repo.createPalace(name.trim() || "Untitled palace", atlasPath?.trim() || null);
+      await recordAnalytics({
+        eventType: "palace_created",
+        eventGroup: "palace",
+        palaceId: p.id,
+        sessionId: null,
+        payload: {
+          name: p.name,
+          atlasPath: p.atlasPath ?? null,
+        },
+      });
       await get().loadPalaces();
       await get().openPalace(p.id);
     },
@@ -184,6 +347,16 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
         draftRestored: false,
       }));
       await get().loadPalaces();
+      await recordAnalytics({
+        eventType: "palace_saved",
+        eventGroup: "palace",
+        palaceId: snap.palace.id,
+        payload: {
+          nodeCount: snap.nodes.length,
+          edgeCount: snap.edges.length,
+          routeCount: snap.routes.length,
+        },
+      });
     },
 
     async flushDraftSave() {
@@ -238,6 +411,15 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
         walkRouteId: walkRouteId ?? r.id,
       });
       scheduleDraftSave();
+      void recordAnalytics({
+        eventType: "route_created",
+        eventGroup: "graph",
+        palaceId: currentPalace.id,
+        routeId: r.id,
+        payload: {
+          name: r.name,
+        },
+      });
     },
 
     addLocusForSelectedRoute(nodeId: string, label = "") {
@@ -254,29 +436,213 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       };
       set({ loci: [...loci, l] });
       scheduleDraftSave();
+      void recordAnalytics({
+        eventType: "locus_added",
+        eventGroup: "graph",
+        routeId,
+        nodeId,
+        payload: {
+          locusId: l.id,
+          orderIndex: l.orderIndex,
+          label: l.label,
+        },
+      });
     },
 
     updateLocusLabel(locusId: string, label: string) {
       const { loci } = get();
+      const previous = loci.find((locus) => locus.id === locusId);
       set({
         loci: loci.map((l) => (l.id === locusId ? { ...l, label } : l)),
       });
       scheduleDraftSave();
+      if (previous && previous.label !== label) {
+        void recordAnalytics({
+          eventType: "locus_updated",
+          eventGroup: "graph",
+          routeId: previous.routeId,
+          nodeId: previous.nodeId,
+          payload: {
+            locusId,
+            fromLabel: previous.label,
+            toLabel: label,
+            orderIndex: previous.orderIndex,
+          },
+        });
+      }
     },
 
     replaceRoutesAndLoci(routes, loci) {
+      const { currentPalace, routes: prevRoutes, loci: prevLoci } = get();
       set({
         routes,
         loci,
         walkRouteId: routes[0]?.id ?? null,
         walkIndex: 0,
         walkOpen: false,
+        walkStepEnteredAt: null,
       });
       scheduleDraftSave();
+      if (!currentPalace) return;
+      const previousRoutesById = new Map(prevRoutes.map((route) => [route.id, route]));
+      const previousLociById = new Map(prevLoci.map((locus) => [locus.id, locus]));
+      const events: AnalyticsEvent[] = [];
+
+      for (const route of routes) {
+        if (previousRoutesById.has(route.id)) continue;
+        events.push(
+          createAnalyticsEvent({
+            eventType: "route_created",
+            eventGroup: "graph",
+            sessionId: get().analyticsSessionId,
+            palaceId: currentPalace.id,
+            routeId: route.id,
+            payload: { name: route.name },
+          }),
+        );
+      }
+
+      for (const locus of loci) {
+        const previous = previousLociById.get(locus.id);
+        if (!previous) {
+          events.push(
+            createAnalyticsEvent({
+              eventType: "locus_added",
+              eventGroup: "graph",
+              sessionId: get().analyticsSessionId,
+              palaceId: currentPalace.id,
+              routeId: locus.routeId,
+              nodeId: locus.nodeId,
+              payload: {
+                locusId: locus.id,
+                orderIndex: locus.orderIndex,
+                label: locus.label,
+              },
+            }),
+          );
+          continue;
+        }
+        if (
+          previous.label === locus.label &&
+          previous.orderIndex === locus.orderIndex &&
+          previous.routeId === locus.routeId &&
+          previous.nodeId === locus.nodeId
+        ) {
+          continue;
+        }
+        events.push(
+          createAnalyticsEvent({
+            eventType: "locus_updated",
+            eventGroup: "graph",
+            sessionId: get().analyticsSessionId,
+            palaceId: currentPalace.id,
+            routeId: locus.routeId,
+            nodeId: locus.nodeId,
+            payload: {
+              locusId: locus.id,
+              previousRouteId: previous.routeId,
+              previousNodeId: previous.nodeId,
+              previousOrderIndex: previous.orderIndex,
+              previousLabel: previous.label,
+              nextOrderIndex: locus.orderIndex,
+              nextLabel: locus.label,
+            },
+          }),
+        );
+      }
+
+      void appendAnalyticsEvents(events);
     },
 
-    setWalkRoute: (walkRouteId) => set({ walkRouteId, walkIndex: 0 }),
-    setWalkOpen: (walkOpen) => set({ walkOpen }),
+    setWalkRoute(walkRouteId) {
+      const wasOpen = get().walkOpen;
+      set({ walkRouteId, walkIndex: 0 });
+      if (!wasOpen || !walkRouteId) return;
+      const context = getWalkContext();
+      if (context.routeId) {
+        void recordAnalytics({
+          eventType: "walk_started",
+          eventGroup: "review",
+          routeId: context.routeId,
+          nodeId: context.nodeId,
+          payload: {
+            source: "route_change",
+            routeLength: context.count,
+            routeName: context.routeName,
+          },
+        });
+      }
+      noteWalkStepEntered("route_change");
+    },
+    setWalkOpen(walkOpen) {
+      const state = get();
+      const wasOpen = state.walkOpen;
+      const previousContext = getWalkContext();
+      set({
+        walkOpen,
+        walkIndex: walkOpen && !wasOpen ? 0 : state.walkIndex,
+        walkStepEnteredAt: walkOpen ? state.walkStepEnteredAt : null,
+      });
+
+      if (!walkOpen) {
+        if (wasOpen && previousContext.routeId) {
+          void recordAnalytics({
+            eventType: "walk_closed",
+            eventGroup: "review",
+            routeId: previousContext.routeId,
+            nodeId: previousContext.nodeId,
+            payload: {
+              stepIndex: previousContext.stepIndex,
+              routeLength: previousContext.count,
+              routeName: previousContext.routeName,
+            },
+          });
+        }
+        set({ walkStepEnteredAt: null });
+        return;
+      }
+
+      if (!wasOpen) {
+        const context = getWalkContext();
+        if (context.routeId) {
+          void recordAnalytics({
+            eventType: "walk_started",
+            eventGroup: "review",
+            routeId: context.routeId,
+            nodeId: context.nodeId,
+            payload: {
+              source: "toggle",
+              routeLength: context.count,
+              routeName: context.routeName,
+            },
+          });
+        }
+        noteWalkStepEntered("open");
+      }
+    },
+
+    rateWalkRecall(rating) {
+      const context = getWalkContext();
+      if (!context.routeId || !context.nodeId) return;
+      const enteredAt = get().walkStepEnteredAt;
+      const now = Date.now();
+      const timeToRevealMs = enteredAt ? Math.max(0, now - Date.parse(enteredAt)) : null;
+      set({ walkStepEnteredAt: new Date(now).toISOString() });
+      void recordAnalytics({
+        eventType: "walk_recall_rated",
+        eventGroup: "review",
+        routeId: context.routeId,
+        nodeId: context.nodeId,
+        payload: {
+          rating,
+          stepIndex: context.stepIndex,
+          routeLength: context.count,
+          locusId: context.locus?.id ?? null,
+          routeName: context.routeName,
+          timeToRevealMs,
+        },
+      });
+    },
 
     walkNext() {
       const { loci, routes, walkRouteId, walkIndex } = get();
@@ -284,6 +650,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       if (!effectiveRouteId) return;
       const list = orderedLoci(loci.filter((l) => l.routeId === effectiveRouteId));
       set({ walkIndex: nextWalkIndex(walkIndex, list.length) });
+      noteWalkStepEntered("next");
     },
 
     walkPrev() {
@@ -292,6 +659,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       if (!effectiveRouteId) return;
       const list = orderedLoci(loci.filter((l) => l.routeId === effectiveRouteId));
       set({ walkIndex: prevWalkIndex(walkIndex, list.length) });
+      noteWalkStepEntered("prev");
     },
 
     currentWalkNodeId() {
@@ -315,6 +683,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
         walkRouteId: s.routes[0]?.id ?? null,
         walkIndex: 0,
         walkOpen: false,
+        walkStepEnteredAt: null,
         selectedShapeId: null,
         persistenceState: options?.persistenceState ?? "clean",
         draftRestored: options?.draftRestored ?? false,

--- a/tests/ui/essential-workflows.spec.ts
+++ b/tests/ui/essential-workflows.spec.ts
@@ -126,6 +126,46 @@ test("route and walk workflow", async ({ page }) => {
   await expect(page.getByText("Step 1/2")).toBeVisible();
 });
 
+test("analytics panel shows local review and graph telemetry", async ({ page }) => {
+  await bootstrapTutorialPalace(page);
+
+  await page.getByRole("button", { name: /^Node$/ }).click();
+  await page.locator("#mp-title").fill("Analytics Node");
+  await page.getByRole("button", { name: "Apply" }).click();
+
+  await page.getByPlaceholder("Route name").fill("Telemetry Route");
+  await page.getByRole("button", { name: "Add route" }).click();
+  await page.getByRole("button", { name: /add selected node to route/i }).click();
+
+  await page.getByRole("button", { name: "Toggle walk mode" }).click();
+  await page.getByRole("button", { name: "Good" }).click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const store = (window as { __mp_store?: { getState: () => unknown } }).__mp_store;
+        if (!store) throw new Error("missing dev store hook");
+        const state = store.getState() as { analyticsEvents: Array<{ eventType: string }> };
+        return {
+          nodeCreated: state.analyticsEvents.some((event) => event.eventType === "node_created"),
+          routeCreated: state.analyticsEvents.some((event) => event.eventType === "route_created"),
+          recallRated: state.analyticsEvents.some((event) => event.eventType === "walk_recall_rated"),
+        };
+      }),
+    )
+    .toMatchObject({
+      nodeCreated: true,
+      routeCreated: true,
+      recallRated: true,
+    });
+
+  await page.getByRole("button", { name: "Analytics" }).click();
+  await expect(page.getByText(/local-first telemetry for encoding and retrieval/i)).toBeVisible();
+  await expect(page.getByText("Recent events")).toBeVisible();
+  await expect(page.getByText(/walk recall rated/i)).toBeVisible();
+  await expect(page.getByText(/graph work: node create\/update, edge create\/update/i)).toBeVisible();
+});
+
 test("connect workflow opens and applies CAST", async ({ page }) => {
   await bootstrapTutorialPalace(page);
 


### PR DESCRIPTION
## Summary
- add a local-first analytics event ledger in browser fallback and Tauri SQLite
- record palace, graph, route, walk, recall-rating, and theSystem materialization events in the store and canvas
- add an Analytics panel plus ranked BDD backlog docs for the remaining high-ROI features

## Verification
- npm.cmd run typecheck
- npm.cmd test
- npx.cmd playwright test --workers=1
- npm.cmd run build
- cargo check