### PR TITLE
Add recall-first walk mode

### DIFF
--- a/src/canvas/MemoryPalaceCanvas.tsx
+++ b/src/canvas/MemoryPalaceCanvas.tsx
@@ -28,6 +28,8 @@ export function MemoryPalaceCanvas({ palaceId, editorSnapshot }: Props) {
   const setSelectedShapeId = usePalaceStore((s) => s.setSelectedShapeId);
   const queueDraftSave = usePalaceStore((s) => s.queueDraftSave);
   const walkOpen = usePalaceStore((s) => s.walkOpen);
+  const walkRecallMode = usePalaceStore((s) => s.walkRecallMode);
+  const walkAnswerRevealed = usePalaceStore((s) => s.walkAnswerRevealed);
   const walkIndex = usePalaceStore((s) => s.walkIndex);
   const walkRouteId = usePalaceStore((s) => s.walkRouteId);
   const loci = usePalaceStore((s) => s.loci);
@@ -191,13 +193,18 @@ export function MemoryPalaceCanvas({ palaceId, editorSnapshot }: Props) {
 
     if (activeShapeId) {
       editor.setHintingShapes([activeShapeId]);
-      editor.setSelectedShapes([activeShapeId]);
+      if (walkRecallMode && !walkAnswerRevealed) {
+        editor.setSelectedShapes([]);
+        usePalaceStore.getState().setSelectedShapeId(null);
+      } else {
+        editor.setSelectedShapes([activeShapeId]);
+      }
       if (lastWalkNodeIdRef.current !== nodeId) {
         editor.zoomToSelectionIfOffscreen(96, { animation: { duration: 260 } });
         lastWalkNodeIdRef.current = nodeId;
       }
     }
-  }, [walkOpen, walkIndex, walkRouteId, loci]);
+  }, [walkAnswerRevealed, walkOpen, walkRecallMode, walkIndex, walkRouteId, loci]);
 
   return (
     <div className="relative h-full min-h-0 w-full flex-1">

--- a/src/components/AnalyticsPanel.tsx
+++ b/src/components/AnalyticsPanel.tsx
@@ -15,6 +15,9 @@ function formatEventDetail(event: AnalyticsEvent) {
     const latency = typeof payload.timeToRevealMs === "number" ? `${payload.timeToRevealMs} ms` : "no timer";
     return `${rating} • ${latency}`;
   }
+  if (event.eventType === "walk_answer_revealed") {
+    return typeof payload.timeToRevealMs === "number" ? `${payload.timeToRevealMs} ms to reveal` : "answer revealed";
+  }
   if (event.eventType === "node_created" || event.eventType === "node_updated") {
     return typeof payload.title === "string" && payload.title.trim() ? payload.title : "memory node";
   }
@@ -118,7 +121,7 @@ export function AnalyticsPanel() {
             <ul className="mt-3 space-y-1 text-sm text-zinc-300">
               <li>- Palace lifecycle: created, opened, draft-saved, checkpoint-saved.</li>
               <li>- Graph work: node create/update, edge create/update, route create, locus add/update.</li>
-              <li>- Review flow: walk start, step changes, recall ratings, walk close.</li>
+              <li>- Review flow: walk start, step changes, answer reveals, recall ratings, walk close.</li>
               <li>- theSystem runs: pipeline materialization into graph structure.</li>
             </ul>
           </section>
@@ -145,7 +148,9 @@ export function AnalyticsPanel() {
               <div className="rounded border border-zinc-800 bg-zinc-950/40 px-3 py-2">
                 <div className="text-zinc-500">Review actions</div>
                 <div className="font-semibold text-zinc-100">
-                  {(allSummary.currentSessionCounts.walk_stepped ?? 0) + (allSummary.currentSessionCounts.walk_recall_rated ?? 0)}
+                  {(allSummary.currentSessionCounts.walk_stepped ?? 0) +
+                    (allSummary.currentSessionCounts.walk_answer_revealed ?? 0) +
+                    (allSummary.currentSessionCounts.walk_recall_rated ?? 0)}
                 </div>
               </div>
             </div>

--- a/src/components/WalkModeBar.tsx
+++ b/src/components/WalkModeBar.tsx
@@ -1,18 +1,110 @@
-import { ChevronLeft, ChevronRight, Footprints } from "lucide-react";
+import { ChevronLeft, ChevronRight, Eye, Footprints } from "lucide-react";
 import { useMemo } from "react";
 import { Button } from "./ui/button";
 import { usePalaceStore } from "../store/palaceStore";
-import { orderedLoci, locusAtOrderedIndex } from "../domain/services/walkService";
+import { orderedLoci } from "../domain/services/walkService";
 import { resolveMemoryNodeTitle } from "../canvas/readShapeText";
 
 type Props = {
   onHoverHintChange?: (hint: string | null) => void;
 };
 
+type NodeReviewState = {
+  title: string;
+  content: string;
+};
+
+function resolveCurrentNodeReviewState(
+  nodeId: string | null,
+  editorRef: ReturnType<typeof usePalaceStore.getState>["editorRef"],
+  snapshotNodes: ReturnType<typeof usePalaceStore.getState>["nodes"],
+): NodeReviewState {
+  if (!nodeId) return { title: "No node", content: "" };
+  if (editorRef) {
+    for (const id of editorRef.getCurrentPageShapeIds()) {
+      const shape = editorRef.getShape(id);
+      if (shape?.type !== "geo") continue;
+      const meta = shape.meta as { mpNodeId?: string; mpContent?: string };
+      if (meta.mpNodeId !== nodeId) continue;
+      return {
+        title: resolveMemoryNodeTitle(shape),
+        content: meta.mpContent?.trim() || "",
+      };
+    }
+  }
+  const snapshotNode = snapshotNodes.find((node) => node.id === nodeId);
+  return {
+    title: snapshotNode?.title || nodeId.slice(0, 8),
+    content: snapshotNode?.content?.trim() || "",
+  };
+}
+
+function RecallRatingButtons({
+  onHoverHintChange,
+}: {
+  onHoverHintChange?: (hint: string | null) => void;
+}) {
+  const rateWalkRecall = usePalaceStore((s) => s.rateWalkRecall);
+
+  return (
+    <div className="flex items-center justify-end gap-1">
+      <Button
+        size="sm"
+        variant="outline"
+        type="button"
+        className="border-rose-800/70 bg-rose-950/30 text-rose-100 hover:bg-rose-900/40"
+        onClick={() => rateWalkRecall("again")}
+        onMouseEnter={() => onHoverHintChange?.("Rate recall as Fail. This marks a miss and keeps the weakness visible.")}
+        onMouseLeave={() => onHoverHintChange?.(null)}
+      >
+        Fail
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        type="button"
+        className="border-amber-800/70 bg-amber-950/30 text-amber-100 hover:bg-amber-900/40"
+        onClick={() => rateWalkRecall("hard")}
+        onMouseEnter={() => onHoverHintChange?.("Rate recall as Hard. You got there, but with friction.")}
+        onMouseLeave={() => onHoverHintChange?.(null)}
+      >
+        Hard
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        type="button"
+        className="border-emerald-800/70 bg-emerald-950/30 text-emerald-100 hover:bg-emerald-900/40"
+        onClick={() => rateWalkRecall("good")}
+        onMouseEnter={() => onHoverHintChange?.("Rate recall as Good. Stable retrieval with acceptable effort.")}
+        onMouseLeave={() => onHoverHintChange?.(null)}
+      >
+        Good
+      </Button>
+      <Button
+        size="sm"
+        variant="outline"
+        type="button"
+        className="border-cyan-800/70 bg-cyan-950/30 text-cyan-100 hover:bg-cyan-900/40"
+        onClick={() => rateWalkRecall("easy")}
+        onMouseEnter={() => onHoverHintChange?.("Rate recall as Easy. Fast, clean retrieval with low effort.")}
+        onMouseLeave={() => onHoverHintChange?.(null)}
+      >
+        Easy
+      </Button>
+    </div>
+  );
+}
+
 export function WalkModeBar({ onHoverHintChange }: Props) {
   const walkOpen = usePalaceStore((s) => s.walkOpen);
   const setWalkOpen = usePalaceStore((s) => s.setWalkOpen);
-  const rateWalkRecall = usePalaceStore((s) => s.rateWalkRecall);
+  const walkRecallMode = usePalaceStore((s) => s.walkRecallMode);
+  const setWalkRecallMode = usePalaceStore((s) => s.setWalkRecallMode);
+  const walkCueOnly = usePalaceStore((s) => s.walkCueOnly);
+  const setWalkCueOnly = usePalaceStore((s) => s.setWalkCueOnly);
+  const walkAnswerRevealed = usePalaceStore((s) => s.walkAnswerRevealed);
+  const revealWalkAnswer = usePalaceStore((s) => s.revealWalkAnswer);
   const walkNext = usePalaceStore((s) => s.walkNext);
   const walkPrev = usePalaceStore((s) => s.walkPrev);
   const routes = usePalaceStore((s) => s.routes);
@@ -20,29 +112,29 @@ export function WalkModeBar({ onHoverHintChange }: Props) {
   const loci = usePalaceStore((s) => s.loci);
   const walkIndex = usePalaceStore((s) => s.walkIndex);
   const editorRef = usePalaceStore((s) => s.editorRef);
+  const snapshotNodes = usePalaceStore((s) => s.nodes);
 
   const effectiveRouteId = walkRouteId ?? routes[0]?.id ?? null;
-  const count = effectiveRouteId ? loci.filter((l) => l.routeId === effectiveRouteId).length : 0;
-  const routeName = routes.find((r) => r.id === effectiveRouteId)?.name ?? "No route";
+  const currentRouteLoci = useMemo(
+    () => orderedLoci(effectiveRouteId ? loci.filter((locus) => locus.routeId === effectiveRouteId) : []),
+    [effectiveRouteId, loci],
+  );
+  const count = currentRouteLoci.length;
+  const currentLocus = currentRouteLoci[walkIndex] ?? null;
+  const routeName = routes.find((route) => route.id === effectiveRouteId)?.name ?? "No route";
 
-  const nodeId = usePalaceStore((s) => {
-    const routeId = s.walkRouteId ?? s.routes[0]?.id ?? null;
-    if (!routeId) return null;
-    const list = orderedLoci(s.loci.filter((l) => l.routeId === routeId));
-    return locusAtOrderedIndex(list, s.walkIndex)?.nodeId ?? null;
-  });
+  const nodeState = useMemo(
+    () => resolveCurrentNodeReviewState(currentLocus?.nodeId ?? null, editorRef, snapshotNodes),
+    [currentLocus?.nodeId, editorRef, snapshotNodes],
+  );
 
-  const title = useMemo(() => {
-    if (!nodeId || !editorRef) return "No node";
-    for (const id of editorRef.getCurrentPageShapeIds()) {
-      const s = editorRef.getShape(id);
-      if (s?.type === "geo" && (s.meta as { mpNodeId?: string }).mpNodeId === nodeId) {
-        return resolveMemoryNodeTitle(s);
-      }
-    }
-    return nodeId.slice(0, 8);
-  }, [nodeId, editorRef]);
-
+  const cueText = walkCueOnly ? nodeState.title : currentLocus?.label?.trim() || nodeState.title;
+  const answerText = walkCueOnly
+    ? nodeState.content || nodeState.title
+    : [nodeState.title, nodeState.content].filter(Boolean).join(" - ");
+  const promptText = walkCueOnly
+    ? "Recall the explanation before you reveal it."
+    : "Use the locus cue first, then reveal the full answer.";
   const progressPct = count > 0 ? Math.round(((walkIndex + 1) / count) * 100) : 0;
 
   return (
@@ -67,96 +159,115 @@ export function WalkModeBar({ onHoverHintChange }: Props) {
       </Button>
       {walkOpen ? (
         <>
-          <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden">
-            <span className="rounded bg-violet-700/70 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-violet-100">
-              Walk active
-            </span>
-            <span className="hidden min-w-0 max-w-48 items-center rounded bg-zinc-800 px-2 py-0.5 text-[11px] text-zinc-300 sm:inline-flex">
-              Route:
-              <span className="ml-1 truncate">{routeName}</span>
-            </span>
-            <div className="flex min-w-0 flex-1 items-center gap-1 text-xs font-medium text-violet-100">
-              <span className="shrink-0">Step {count ? walkIndex + 1 : 0}/{count}</span>
-              <span className="text-violet-300">-</span>
-              <span className="truncate">{title}</span>
+          <Button
+            size="sm"
+            type="button"
+            variant={walkRecallMode ? "default" : "secondary"}
+            onClick={() => setWalkRecallMode(!walkRecallMode)}
+            onMouseEnter={() => onHoverHintChange?.("Recall-first: hide the answer until you explicitly reveal it.")}
+            onMouseLeave={() => onHoverHintChange?.(null)}
+          >
+            Recall-first
+          </Button>
+          <Button
+            size="sm"
+            type="button"
+            variant={walkCueOnly ? "secondary" : "ghost"}
+            disabled={!walkRecallMode}
+            onClick={() => setWalkCueOnly(!walkCueOnly)}
+            onMouseEnter={() =>
+              onHoverHintChange?.("Cue-only: use the node title as the prompt and keep the fuller explanation hidden.")
+            }
+            onMouseLeave={() => onHoverHintChange?.(null)}
+          >
+            Cue only
+          </Button>
+
+          <div className="flex min-w-0 flex-1 flex-col gap-1 overflow-hidden">
+            <div className="flex min-w-0 items-center gap-2 overflow-hidden">
+              <span className="rounded bg-violet-700/70 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-violet-100">
+                {walkRecallMode ? "Recall-first" : "Walk active"}
+              </span>
+              <span className="hidden min-w-0 max-w-48 items-center rounded bg-zinc-800 px-2 py-0.5 text-[11px] text-zinc-300 sm:inline-flex">
+                Route:
+                <span className="ml-1 truncate">{routeName}</span>
+              </span>
+              <span className="rounded bg-zinc-800 px-2 py-0.5 text-[11px] text-zinc-300">
+                Step {count ? walkIndex + 1 : 0}/{count}
+              </span>
+              {currentLocus?.label?.trim() ? (
+                <span className="hidden min-w-0 max-w-52 truncate rounded bg-zinc-900/70 px-2 py-0.5 text-[11px] text-zinc-400 md:inline-flex">
+                  Locus: {currentLocus.label}
+                </span>
+              ) : null}
             </div>
-            <div className="hidden h-1.5 w-28 shrink-0 overflow-hidden rounded-full bg-zinc-800 lg:block">
-              <div className="h-full bg-violet-400 transition-all" style={{ width: `${progressPct}%` }} />
+
+            <div className="flex min-w-0 items-start gap-2 overflow-hidden">
+              <div className="min-w-0 flex-1">
+                <div id="walk-cue" className="truncate text-sm font-semibold text-violet-100">
+                  {cueText || "No cue"}
+                </div>
+                <div
+                  id="walk-answer"
+                  className="h-5 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs leading-5 text-zinc-300"
+                >
+                  {walkRecallMode && !walkAnswerRevealed ? promptText : answerText || "No saved answer on this node yet."}
+                </div>
+              </div>
+              <div className="hidden h-1.5 w-28 shrink-0 overflow-hidden rounded-full bg-zinc-800 lg:block">
+                <div className="h-full bg-violet-400 transition-all" style={{ width: `${progressPct}%` }} />
+              </div>
             </div>
           </div>
+
           <div className="ml-auto flex shrink-0 items-center gap-2 border-l border-zinc-800/80 pl-2">
-            <div className="hidden items-center gap-1 lg:flex">
+            <div className="flex min-w-[12rem] justify-end md:min-w-[16rem] lg:min-w-[20rem]">
+              {walkRecallMode && !walkAnswerRevealed ? (
+                <Button
+                  size="sm"
+                  type="button"
+                  aria-label="Reveal answer"
+                  className="ml-auto"
+                  onClick={() => revealWalkAnswer()}
+                  onMouseEnter={() => onHoverHintChange?.("Reveal the hidden answer for this step and unlock grading.")}
+                  onMouseLeave={() => onHoverHintChange?.(null)}
+                >
+                  <Eye className="h-4 w-4" />
+                  Reveal
+                </Button>
+              ) : (
+                <RecallRatingButtons onHoverHintChange={onHoverHintChange} />
+              )}
+            </div>
+
+            <div className="flex items-center gap-1">
               <Button
                 size="sm"
-                variant="outline"
+                variant="ghost"
                 type="button"
-                className="border-rose-800/70 bg-rose-950/30 text-rose-100 hover:bg-rose-900/40"
-                onClick={() => rateWalkRecall("again")}
-                onMouseEnter={() => onHoverHintChange?.("Rate recall as Again. Analytics stays local and tracks weak spots.")}
+                aria-label="Previous step"
+                className="shrink-0"
+                onClick={() => walkPrev()}
+                disabled={walkIndex <= 0}
+                onMouseEnter={() => onHoverHintChange?.("Previous locus in current route.")}
                 onMouseLeave={() => onHoverHintChange?.(null)}
               >
-                Again
+                <ChevronLeft className="h-4 w-4" />
               </Button>
               <Button
                 size="sm"
-                variant="outline"
+                variant="ghost"
                 type="button"
-                className="border-amber-800/70 bg-amber-950/30 text-amber-100 hover:bg-amber-900/40"
-                onClick={() => rateWalkRecall("hard")}
-                onMouseEnter={() => onHoverHintChange?.("Rate recall as Hard. This marks effortful retrieval without full failure.")}
+                aria-label="Next step"
+                className="shrink-0"
+                onClick={() => walkNext()}
+                disabled={count === 0 || walkIndex >= count - 1}
+                onMouseEnter={() => onHoverHintChange?.("Next locus in current route.")}
                 onMouseLeave={() => onHoverHintChange?.(null)}
               >
-                Hard
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                type="button"
-                className="border-emerald-800/70 bg-emerald-950/30 text-emerald-100 hover:bg-emerald-900/40"
-                onClick={() => rateWalkRecall("good")}
-                onMouseEnter={() => onHoverHintChange?.("Rate recall as Good. Useful for review timing and strength analytics.")}
-                onMouseLeave={() => onHoverHintChange?.(null)}
-              >
-                Good
-              </Button>
-              <Button
-                size="sm"
-                variant="outline"
-                type="button"
-                className="border-cyan-800/70 bg-cyan-950/30 text-cyan-100 hover:bg-cyan-900/40"
-                onClick={() => rateWalkRecall("easy")}
-                onMouseEnter={() => onHoverHintChange?.("Rate recall as Easy. Fast, stable recall should trend toward this.")}
-                onMouseLeave={() => onHoverHintChange?.(null)}
-              >
-                Easy
+                <ChevronRight className="h-4 w-4" />
               </Button>
             </div>
-            <Button
-              size="sm"
-              variant="ghost"
-              type="button"
-              aria-label="Previous step"
-              className="shrink-0"
-              onClick={() => walkPrev()}
-              disabled={walkIndex <= 0}
-              onMouseEnter={() => onHoverHintChange?.("Previous locus in current route.")}
-              onMouseLeave={() => onHoverHintChange?.(null)}
-            >
-              <ChevronLeft className="h-4 w-4" />
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              type="button"
-              aria-label="Next step"
-              className="shrink-0"
-              onClick={() => walkNext()}
-              disabled={count === 0 || walkIndex >= count - 1}
-              onMouseEnter={() => onHoverHintChange?.("Next locus in current route.")}
-              onMouseLeave={() => onHoverHintChange?.(null)}
-            >
-              <ChevronRight className="h-4 w-4" />
-            </Button>
           </div>
         </>
       ) : null}

--- a/src/domain/entities/types.ts
+++ b/src/domain/entities/types.ts
@@ -81,6 +81,7 @@ export type AnalyticsEventType =
   | "locus_updated"
   | "walk_started"
   | "walk_stepped"
+  | "walk_answer_revealed"
   | "walk_recall_rated"
   | "walk_closed"
   | "system_run_materialized";

--- a/src/store/palaceStore.ts
+++ b/src/store/palaceStore.ts
@@ -57,7 +57,12 @@ export type PalaceStore = {
   walkOpen: boolean;
   walkRouteId: string | null;
   walkIndex: number;
+  walkRecallMode: boolean;
+  walkCueOnly: boolean;
+  walkAnswerRevealed: boolean;
   walkStepEnteredAt: string | null;
+  walkRevealedAt: string | null;
+  walkRevealLatencyMs: number | null;
   persistenceState: PalacePersistenceState;
   lastDraftSavedAt: string | null;
   draftRestored: boolean;
@@ -82,6 +87,9 @@ export type PalaceStore = {
   replaceRoutesAndLoci: (routes: MemoryRoute[], loci: Locus[]) => void;
   setWalkRoute: (routeId: string | null) => void;
   setWalkOpen: (v: boolean) => void;
+  setWalkRecallMode: (v: boolean) => void;
+  setWalkCueOnly: (v: boolean) => void;
+  revealWalkAnswer: () => void;
   rateWalkRecall: (rating: RecallRating) => void;
   walkNext: () => void;
   walkPrev: () => void;
@@ -177,7 +185,12 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
 
   const noteWalkStepEntered = (direction: "open" | "next" | "prev" | "route_change") => {
     const enteredAt = new Date().toISOString();
-    set({ walkStepEnteredAt: enteredAt });
+    set((state) => ({
+      walkStepEnteredAt: enteredAt,
+      walkRevealedAt: null,
+      walkRevealLatencyMs: null,
+      walkAnswerRevealed: !state.walkRecallMode,
+    }));
     const context = getWalkContext();
     if (!context.routeId || !context.nodeId) return;
     void recordAnalytics({
@@ -252,7 +265,12 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
     walkOpen: false,
     walkRouteId: null,
     walkIndex: 0,
+    walkRecallMode: false,
+    walkCueOnly: true,
+    walkAnswerRevealed: true,
     walkStepEnteredAt: null,
+    walkRevealedAt: null,
+    walkRevealLatencyMs: null,
     persistenceState: "clean",
     lastDraftSavedAt: null,
     draftRestored: false,
@@ -480,7 +498,10 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
         walkRouteId: routes[0]?.id ?? null,
         walkIndex: 0,
         walkOpen: false,
+        walkAnswerRevealed: !get().walkRecallMode,
         walkStepEnteredAt: null,
+        walkRevealedAt: null,
+        walkRevealLatencyMs: null,
       });
       scheduleDraftSave();
       if (!currentPalace) return;
@@ -556,7 +577,14 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
 
     setWalkRoute(walkRouteId) {
       const wasOpen = get().walkOpen;
-      set({ walkRouteId, walkIndex: 0 });
+      set((state) => ({
+        walkRouteId,
+        walkIndex: 0,
+        walkAnswerRevealed: !state.walkRecallMode,
+        walkStepEnteredAt: null,
+        walkRevealedAt: null,
+        walkRevealLatencyMs: null,
+      }));
       if (!wasOpen || !walkRouteId) return;
       const context = getWalkContext();
       if (context.routeId) {
@@ -581,7 +609,10 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       set({
         walkOpen,
         walkIndex: walkOpen && !wasOpen ? 0 : state.walkIndex,
+        walkAnswerRevealed: walkOpen ? !state.walkRecallMode : false,
         walkStepEnteredAt: walkOpen ? state.walkStepEnteredAt : null,
+        walkRevealedAt: null,
+        walkRevealLatencyMs: null,
       });
 
       if (!walkOpen) {
@@ -598,7 +629,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
             },
           });
         }
-        set({ walkStepEnteredAt: null });
+        set({ walkStepEnteredAt: null, walkRevealedAt: null, walkRevealLatencyMs: null });
         return;
       }
 
@@ -621,13 +652,62 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       }
     },
 
-    rateWalkRecall(rating) {
+    setWalkRecallMode(walkRecallMode) {
+      const enteredAt = new Date().toISOString();
+      set({
+        walkRecallMode,
+        walkAnswerRevealed: !walkRecallMode,
+        walkStepEnteredAt: get().walkOpen ? enteredAt : null,
+        walkRevealedAt: null,
+        walkRevealLatencyMs: null,
+      });
+    },
+
+    setWalkCueOnly(walkCueOnly) {
+      set({ walkCueOnly });
+    },
+
+    revealWalkAnswer() {
       const context = getWalkContext();
-      if (!context.routeId || !context.nodeId) return;
       const enteredAt = get().walkStepEnteredAt;
       const now = Date.now();
       const timeToRevealMs = enteredAt ? Math.max(0, now - Date.parse(enteredAt)) : null;
-      set({ walkStepEnteredAt: new Date(now).toISOString() });
+      set({
+        walkAnswerRevealed: true,
+        walkRevealedAt: new Date(now).toISOString(),
+        walkRevealLatencyMs: timeToRevealMs,
+      });
+      if (!context.routeId || !context.nodeId) return;
+      void recordAnalytics({
+        eventType: "walk_answer_revealed",
+        eventGroup: "review",
+        routeId: context.routeId,
+        nodeId: context.nodeId,
+        payload: {
+          stepIndex: context.stepIndex,
+          routeLength: context.count,
+          locusId: context.locus?.id ?? null,
+          routeName: context.routeName,
+          timeToRevealMs,
+        },
+      });
+    },
+
+    rateWalkRecall(rating) {
+      const context = getWalkContext();
+      if (!context.routeId || !context.nodeId) return;
+      if (get().walkRecallMode && !get().walkAnswerRevealed) return;
+      const enteredAt = get().walkStepEnteredAt;
+      const revealedAt = get().walkRevealedAt;
+      const revealLatencyMs = get().walkRevealLatencyMs;
+      const now = Date.now();
+      const timeToRevealMs = revealLatencyMs ?? (enteredAt ? Math.max(0, now - Date.parse(enteredAt)) : null);
+      const timeFromRevealToRatingMs = revealedAt ? Math.max(0, now - Date.parse(revealedAt)) : null;
+      set({
+        walkStepEnteredAt: new Date(now).toISOString(),
+        walkRevealedAt: revealedAt,
+        walkRevealLatencyMs: revealLatencyMs,
+      });
       void recordAnalytics({
         eventType: "walk_recall_rated",
         eventGroup: "review",
@@ -640,6 +720,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
           locusId: context.locus?.id ?? null,
           routeName: context.routeName,
           timeToRevealMs,
+          timeFromRevealToRatingMs,
         },
       });
     },
@@ -683,7 +764,10 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
         walkRouteId: s.routes[0]?.id ?? null,
         walkIndex: 0,
         walkOpen: false,
+        walkAnswerRevealed: !state.walkRecallMode,
         walkStepEnteredAt: null,
+        walkRevealedAt: null,
+        walkRevealLatencyMs: null,
         selectedShapeId: null,
         persistenceState: options?.persistenceState ?? "clean",
         draftRestored: options?.draftRestored ?? false,

--- a/tests/ui/walk-mode.spec.ts
+++ b/tests/ui/walk-mode.spec.ts
@@ -23,3 +23,63 @@ test("walk mode steps and active state are visible", async ({ page }) => {
   await expect(page.getByText("Step 1/2")).toBeVisible();
 });
 
+test("recall-first walk mode hides the answer until reveal and keeps controls stable", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("button", { name: /create tutorial palace/i }).click();
+  await expect(page.getByRole("heading", { name: "Tutorial Palace" })).toBeVisible();
+
+  await page.getByRole("button", { name: /^Node$/ }).click();
+  await page.locator("#mp-title").fill("Closure cue");
+  await page.locator("#mp-content").fill("A closure keeps access to the lexical environment that created it.");
+  await page.getByRole("button", { name: "Apply" }).click();
+
+  await page.getByPlaceholder("Route name").fill("Recall Demo");
+  await page.getByRole("button", { name: "Add route" }).click();
+  await page.getByRole("button", { name: /add selected node to route/i }).click();
+
+  await page.getByRole("button", { name: "Toggle walk mode" }).click();
+  await page.getByRole("button", { name: "Recall-first" }).click();
+
+  await expect(page.locator("#walk-cue")).toContainText("Closure cue");
+  await expect(page.getByRole("button", { name: "Reveal answer" })).toBeVisible();
+  await expect(page.locator("#walk-answer")).not.toContainText("lexical environment that created it");
+
+  const nextBefore = await page.getByRole("button", { name: "Next step" }).boundingBox();
+  if (!nextBefore) throw new Error("missing next button position before reveal");
+
+  await page.getByRole("button", { name: "Reveal answer" }).click();
+  await expect(page.locator("#walk-answer")).toContainText("A closure keeps access to the lexical environment that created it.");
+
+  const nextAfter = await page.getByRole("button", { name: "Next step" }).boundingBox();
+  if (!nextAfter) throw new Error("missing next button position after reveal");
+  expect(Math.abs(nextBefore.x - nextAfter.x)).toBeLessThanOrEqual(1);
+  expect(Math.abs(nextBefore.y - nextAfter.y)).toBeLessThanOrEqual(1);
+
+  await page.getByRole("button", { name: "Good" }).click();
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const store = (window as { __mp_store?: { getState: () => unknown } }).__mp_store;
+        if (!store) throw new Error("missing dev store hook");
+        const state = store.getState() as {
+          analyticsEvents: Array<{ eventType: string; payloadJson: string }>;
+        };
+        const revealEvent = state.analyticsEvents.find((event) => event.eventType === "walk_answer_revealed");
+        const ratingEvent = state.analyticsEvents.find((event) => event.eventType === "walk_recall_rated");
+        return {
+          revealed: !!revealEvent,
+          rated: !!ratingEvent,
+          hasRevealTiming: (revealEvent?.payloadJson ?? "").includes("timeToRevealMs"),
+          hasRatingTiming: (ratingEvent?.payloadJson ?? "").includes("timeToRevealMs"),
+        };
+      }),
+    )
+    .toMatchObject({
+      revealed: true,
+      rated: true,
+      hasRevealTiming: true,
+      hasRatingTiming: true,
+    });
+});
+


### PR DESCRIPTION
## Summary
- add recall-first review controls with cue-only mode, explicit reveal, and stable step navigation layout
- hide answer leakage before reveal by clearing active selection during hidden-answer steps
- record reveal timing for later scheduling and cover the flow with Playwright

## Verification
- npm.cmd run typecheck
- npm.cmd test
- npx.cmd playwright test --workers=1
- npm.cmd run build
- cargo check