### PR TITLE
Add spaced review queue

### DIFF
--- a/src/app/MemoryPalaceApp.tsx
+++ b/src/app/MemoryPalaceApp.tsx
@@ -7,8 +7,9 @@ import { RoutePanel } from "../components/RoutePanel";
 import { WalkModeBar } from "../components/WalkModeBar";
 import { NodeInspector } from "../components/NodeInspector";
 import { CastEdgeDialog } from "../components/CastEdgeDialog";
-import { OnboardingPanel } from "../components/OnboardingPanel";
+import { OnboardingPanel, type LearnPanelTab } from "../components/OnboardingPanel";
 import { Button } from "../components/ui/button";
+import { buildReviewQueue, summarizeReviewQueue } from "../domain/services/reviewQueueService";
 import { usePalaceStore } from "../store/palaceStore";
 import { createMemoryArrow } from "../canvas/createMemoryShapes";
 
@@ -22,11 +23,15 @@ export function MemoryPalaceApp() {
   const lastDraftSavedAt = usePalaceStore((s) => s.lastDraftSavedAt);
   const analyticsLoaded = usePalaceStore((s) => s.analyticsLoaded);
   const loadAnalyticsEvents = usePalaceStore((s) => s.loadAnalyticsEvents);
+  const analyticsEvents = usePalaceStore((s) => s.analyticsEvents);
+  const nodes = usePalaceStore((s) => s.nodes);
+  const routes = usePalaceStore((s) => s.routes);
   const [showOnboarding, setShowOnboarding] = useState(true);
   const [showSidebar, setShowSidebar] = useState(true);
   const [showInspector, setShowInspector] = useState(true);
   const [viewMode, setViewMode] = useState<"balanced" | "focus" | "learn">("balanced");
   const [hoverHint, setHoverHint] = useState<string | null>(null);
+  const [preferredLearnTab, setPreferredLearnTab] = useState<LearnPanelTab>("guides");
 
   const snap = currentPalace?.editorSnapshot;
 
@@ -57,6 +62,19 @@ export function MemoryPalaceApp() {
     }
     return "Local · SQLite · Saved checkpoint";
   }, [currentPalace, draftRestored, lastDraftSavedAt, persistenceState]);
+  const reviewSummary = useMemo(() => {
+    if (!currentPalace) {
+      return summarizeReviewQueue([]);
+    }
+    return summarizeReviewQueue(
+      buildReviewQueue({
+        analyticsEvents,
+        palaceId: currentPalace.id,
+        nodes,
+        routes,
+      }),
+    );
+  }, [analyticsEvents, currentPalace, nodes, routes]);
 
   useEffect(() => {
     if (!analyticsLoaded) {
@@ -100,6 +118,11 @@ export function MemoryPalaceApp() {
     }
     setShowSidebar(false);
     setShowInspector(false);
+    setShowOnboarding(true);
+  };
+
+  const openLearnTab = (tab: LearnPanelTab) => {
+    setPreferredLearnTab(tab);
     setShowOnboarding(true);
   };
 
@@ -159,7 +182,7 @@ export function MemoryPalaceApp() {
             size="sm"
             variant="secondary"
             type="button"
-            onClick={() => setShowOnboarding((v) => !v)}
+            onClick={() => openLearnTab("guides")}
             onMouseEnter={() =>
               setHoverHint("Learn panel: onboarding guides plus theSystem pipelines that can materialize into the graph.")
             }
@@ -168,6 +191,19 @@ export function MemoryPalaceApp() {
             <BookOpen className="h-4 w-4" />
             Learn
           </Button>
+          {reviewSummary.dueCount > 0 ? (
+            <Button
+              size="sm"
+              variant="secondary"
+              type="button"
+              className="border-amber-700/70 bg-amber-950/30 text-amber-100 hover:bg-amber-900/40"
+              onClick={() => openLearnTab("review")}
+              onMouseEnter={() => setHoverHint("Review queue: overdue and due-now items for the current palace.")}
+              onMouseLeave={() => setHoverHint(null)}
+            >
+              {reviewSummary.dueCount} due
+            </Button>
+          ) : null}
           <span className="text-xs text-zinc-500">{persistenceLabel}</span>
         </div>
       </header>
@@ -190,6 +226,7 @@ export function MemoryPalaceApp() {
         </main>
         <OnboardingPanel
           open={showOnboarding || palaces.length === 0}
+          preferredTab={preferredLearnTab}
           onClose={() => {
             setShowOnboarding(false);
           }}

--- a/src/components/OnboardingPanel.tsx
+++ b/src/components/OnboardingPanel.tsx
@@ -9,6 +9,7 @@ import { Button } from "./ui/button";
 import type { MemoryPalaceMeta } from "../canvas/memoryMeta";
 import type { Locus, MemoryRoute } from "../domain/entities/types";
 import { AnalyticsPanel } from "./AnalyticsPanel";
+import { ReviewQueuePanel } from "./ReviewQueuePanel";
 import { TheSystemWorkbench } from "./TheSystemWorkbench";
 
 type Lesson = {
@@ -98,12 +99,15 @@ const EXAMPLES: ExampleBlueprint[] = [
   },
 ];
 
+export type LearnPanelTab = "guides" | "system" | "analytics" | "review";
+
 type Props = {
   open: boolean;
   onClose: () => void;
+  preferredTab?: LearnPanelTab;
 };
 
-export function OnboardingPanel({ open, onClose }: Props) {
+export function OnboardingPanel({ open, onClose, preferredTab }: Props) {
   const palaces = usePalaceStore((s) => s.palaces);
   const currentPalace = usePalaceStore((s) => s.currentPalace);
   const routes = usePalaceStore((s) => s.routes);
@@ -116,7 +120,7 @@ export function OnboardingPanel({ open, onClose }: Props) {
   const setToolMode = usePalaceStore((s) => s.setToolMode);
 
   const [lessonId, setLessonId] = useState<string>(LESSONS[0].id);
-  const [panelTab, setPanelTab] = useState<"guides" | "system" | "analytics">("guides");
+  const [panelTab, setPanelTab] = useState<LearnPanelTab>(preferredTab ?? "guides");
   const [loadingExampleId, setLoadingExampleId] = useState<string | null>(null);
   const [, bumpSceneRevision] = useReducer((v: number) => v + 1, 0);
 
@@ -132,6 +136,11 @@ export function OnboardingPanel({ open, onClose }: Props) {
       unlisten();
     };
   }, [editorRef]);
+
+  useEffect(() => {
+    if (!preferredTab) return;
+    setPanelTab(preferredTab);
+  }, [preferredTab]);
 
   const selectedLesson = LESSONS.find((x) => x.id === lessonId) ?? LESSONS[0];
 
@@ -437,6 +446,14 @@ export function OnboardingPanel({ open, onClose }: Props) {
           <Button
             size="sm"
             type="button"
+            variant={panelTab === "review" ? "default" : "secondary"}
+            onClick={() => setPanelTab("review")}
+          >
+            Review
+          </Button>
+          <Button
+            size="sm"
+            type="button"
             variant={panelTab === "analytics" ? "default" : "secondary"}
             onClick={() => setPanelTab("analytics")}
           >
@@ -537,6 +554,10 @@ export function OnboardingPanel({ open, onClose }: Props) {
       ) : panelTab === "system" ? (
         <div className="min-h-0 flex-1 p-3">
           <TheSystemWorkbench />
+        </div>
+      ) : panelTab === "review" ? (
+        <div className="min-h-0 flex-1 p-3">
+          <ReviewQueuePanel />
         </div>
       ) : (
         <div className="min-h-0 flex-1 p-3">

--- a/src/components/ReviewQueuePanel.tsx
+++ b/src/components/ReviewQueuePanel.tsx
@@ -1,0 +1,210 @@
+import { useMemo, type ReactNode } from "react";
+import { AlarmClockCheck, BrainCircuit, Clock3, Route, Sparkles } from "lucide-react";
+import type { ReviewQueueItem } from "../domain/services/reviewQueueService";
+import { buildReviewQueue, summarizeReviewQueue } from "../domain/services/reviewQueueService";
+import { orderedLoci } from "../domain/services/walkService";
+import { usePalaceStore } from "../store/palaceStore";
+import type { TLShapeId } from "@tldraw/tlschema";
+import type { MemoryPalaceMeta } from "../canvas/memoryMeta";
+import { Button } from "./ui/button";
+
+function relativeDueLabel(item: ReviewQueueItem) {
+  if (item.state === "fresh") return "Fresh";
+  if (!item.dueAt) return "Fresh";
+  if (item.state === "due_now") return "Due now";
+  const dueMs = Date.parse(item.dueAt);
+  const deltaMs = dueMs - Date.now();
+  if (item.state === "overdue") {
+    const overdueMinutes = Math.max(1, Math.round(Math.abs(deltaMs) / 60_000));
+    if (overdueMinutes < 60) return `${overdueMinutes}m overdue`;
+    const overdueHours = Math.max(1, Math.round(overdueMinutes / 60));
+    if (overdueHours < 48) return `${overdueHours}h overdue`;
+    return `${Math.max(1, Math.round(overdueHours / 24))}d overdue`;
+  }
+  const dueMinutes = Math.max(1, Math.round(deltaMs / 60_000));
+  if (dueMinutes < 60) return `Due in ${dueMinutes}m`;
+  const dueHours = Math.max(1, Math.round(dueMinutes / 60));
+  if (dueHours < 48) return `Due in ${dueHours}h`;
+  return `Due in ${Math.max(1, Math.round(dueHours / 24))}d`;
+}
+
+function ratingLabel(item: ReviewQueueItem) {
+  if (!item.latestRating) return "No prior grade";
+  return `Last grade: ${item.latestRating}`;
+}
+
+function toneClass(item: ReviewQueueItem) {
+  switch (item.state) {
+    case "overdue":
+      return "border-rose-700/70 bg-rose-950/20";
+    case "due_now":
+      return "border-amber-700/70 bg-amber-950/20";
+    case "fresh":
+      return "border-zinc-800 bg-zinc-900/40";
+    case "scheduled":
+      return "border-emerald-700/60 bg-emerald-950/20";
+    default:
+      return "border-zinc-800 bg-zinc-900/40";
+  }
+}
+
+function Stat({
+  icon,
+  label,
+  value,
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+}) {
+  return (
+    <div className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+      <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-2 text-2xl font-semibold text-zinc-100">{value}</div>
+    </div>
+  );
+}
+
+export function ReviewQueuePanel() {
+  const currentPalace = usePalaceStore((s) => s.currentPalace);
+  const nodes = usePalaceStore((s) => s.nodes);
+  const routes = usePalaceStore((s) => s.routes);
+  const loci = usePalaceStore((s) => s.loci);
+  const analyticsEvents = usePalaceStore((s) => s.analyticsEvents);
+  const editorRef = usePalaceStore((s) => s.editorRef);
+  const setWalkRoute = usePalaceStore((s) => s.setWalkRoute);
+  const setWalkRecallMode = usePalaceStore((s) => s.setWalkRecallMode);
+  const setWalkCueOnly = usePalaceStore((s) => s.setWalkCueOnly);
+  const setWalkOpen = usePalaceStore((s) => s.setWalkOpen);
+
+  const queue = useMemo(
+    () =>
+      buildReviewQueue({
+        analyticsEvents,
+        palaceId: currentPalace?.id ?? null,
+        nodes,
+        routes,
+      }),
+    [analyticsEvents, currentPalace?.id, nodes, routes],
+  );
+  const summary = useMemo(() => summarizeReviewQueue(queue), [queue]);
+
+  const reviewRoute = (item: ReviewQueueItem) => {
+    if (!item.routeId) return;
+    setWalkRoute(item.routeId);
+    setWalkRecallMode(true);
+    setWalkCueOnly(true);
+    setWalkOpen(true);
+  };
+
+  const focusNode = (item: ReviewQueueItem) => {
+    if (!editorRef || !item.nodeId) return;
+    for (const shapeId of editorRef.getCurrentPageShapeIds()) {
+      const shape = editorRef.getShape(shapeId);
+      if (shape?.type !== "geo") continue;
+      const meta = (shape.meta ?? {}) as MemoryPalaceMeta;
+      if (meta.mpNodeId !== item.nodeId) continue;
+      editorRef.setSelectedShapes([shapeId as TLShapeId]);
+      usePalaceStore.getState().setSelectedShapeId(shapeId);
+      editorRef.zoomToSelectionIfOffscreen(120, { animation: { duration: 220 } });
+      break;
+    }
+  };
+
+  const reviewNodeInRoute = (item: ReviewQueueItem) => {
+    if (!item.routeId || !item.nodeId) return;
+    setWalkRoute(item.routeId);
+    setWalkRecallMode(true);
+    setWalkCueOnly(true);
+    setWalkOpen(true);
+    const routeLoci = orderedLoci(loci.filter((locus) => locus.routeId === item.routeId));
+    const targetIndex = routeLoci.findIndex((locus) => locus.nodeId === item.nodeId);
+    if (targetIndex >= 0) {
+      usePalaceStore.setState({ walkIndex: targetIndex });
+    }
+  };
+
+  if (!currentPalace) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border border-dashed border-zinc-800 bg-zinc-950/40 p-6 text-sm text-zinc-500">
+        Open a palace to build its spaced review queue.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="border-b border-zinc-800 pb-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-violet-200">
+          <AlarmClockCheck className="h-4 w-4" />
+          Review Queue
+        </div>
+        <p className="mt-1 max-w-3xl text-xs leading-5 text-zinc-400">
+          Spaced review stays local and schedules route-level and node-level reviews from actual recall performance.
+          Due work stays visible here without blocking normal graph editing.
+        </p>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto py-3">
+        <div className="grid gap-3 md:grid-cols-4">
+          <Stat icon={<Clock3 className="h-3.5 w-3.5" />} label="Due now" value={String(summary.dueCount)} />
+          <Stat icon={<AlarmClockCheck className="h-3.5 w-3.5" />} label="Overdue" value={String(summary.overdueCount)} />
+          <Stat icon={<Sparkles className="h-3.5 w-3.5" />} label="Fresh" value={String(summary.freshCount)} />
+          <Stat icon={<BrainCircuit className="h-3.5 w-3.5" />} label="Scheduled" value={String(summary.scheduledCount)} />
+        </div>
+
+        <div className="mt-3 rounded-md border border-zinc-800 bg-zinc-900/40 p-3 text-xs leading-5 text-zinc-400">
+          Current palace: <span className="text-zinc-200">{currentPalace.name}</span>. Route sessions schedule whole-path
+          reviews, while node grades keep single concepts from being silently neglected.
+        </div>
+
+        <div className="mt-3 space-y-3">
+          {queue.length === 0 ? (
+            <div className="rounded-md border border-dashed border-zinc-800 bg-zinc-950/40 px-3 py-6 text-sm text-zinc-500">
+              No review items yet. Walk a route in recall-first mode and grade recall to seed the queue.
+            </div>
+          ) : (
+            queue.map((item) => (
+              <section key={item.id} className={`rounded-md border p-3 ${toneClass(item)}`}>
+                <div className="flex flex-wrap items-start justify-between gap-3">
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2 text-xs uppercase tracking-wide text-zinc-500">
+                      {item.kind === "route" ? <Route className="h-3.5 w-3.5" /> : <BrainCircuit className="h-3.5 w-3.5" />}
+                      {item.kind}
+                    </div>
+                    <div className="mt-1 text-sm font-semibold text-zinc-100">{item.title}</div>
+                    <div className="mt-1 text-xs text-zinc-400">
+                      {item.subtitle ? `${item.subtitle} • ` : ""}
+                      {ratingLabel(item)} • {relativeDueLabel(item)}
+                    </div>
+                  </div>
+                  <div className="flex flex-wrap justify-end gap-2">
+                    {item.kind === "route" ? (
+                      <Button type="button" size="sm" onClick={() => reviewRoute(item)}>
+                        Review route
+                      </Button>
+                    ) : (
+                      <>
+                        <Button type="button" size="sm" variant="secondary" onClick={() => focusNode(item)}>
+                          Focus node
+                        </Button>
+                        {item.routeId ? (
+                          <Button type="button" size="sm" onClick={() => reviewNodeInRoute(item)}>
+                            Review in route
+                          </Button>
+                        ) : null}
+                      </>
+                    )}
+                  </div>
+                </div>
+              </section>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/domain/services/reviewQueueService.test.ts
+++ b/src/domain/services/reviewQueueService.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import { createAnalyticsEvent } from "./analyticsService";
+import { buildReviewQueue, summarizeReviewQueue } from "./reviewQueueService";
+
+describe("reviewQueueService", () => {
+  it("orders due route and node reviews ahead of fresh and scheduled items", () => {
+    const analyticsEvents = [
+      createAnalyticsEvent({
+        eventType: "walk_recall_rated",
+        eventGroup: "review",
+        sessionId: "walk-a",
+        palaceId: "palace-1",
+        routeId: "route-a",
+        nodeId: "node-a",
+        createdAt: "2026-04-26T09:00:00.000Z",
+        payload: { rating: "again", routeName: "Route A" },
+      }),
+      createAnalyticsEvent({
+        eventType: "walk_closed",
+        eventGroup: "review",
+        sessionId: "walk-a",
+        palaceId: "palace-1",
+        routeId: "route-a",
+        nodeId: "node-a",
+        createdAt: "2026-04-26T09:01:00.000Z",
+        payload: { routeName: "Route A" },
+      }),
+      createAnalyticsEvent({
+        eventType: "walk_recall_rated",
+        eventGroup: "review",
+        sessionId: "walk-b",
+        palaceId: "palace-1",
+        routeId: "route-b",
+        nodeId: "node-b",
+        createdAt: "2026-04-26T09:05:00.000Z",
+        payload: { rating: "easy", routeName: "Route B" },
+      }),
+      createAnalyticsEvent({
+        eventType: "walk_closed",
+        eventGroup: "review",
+        sessionId: "walk-b",
+        palaceId: "palace-1",
+        routeId: "route-b",
+        nodeId: "node-b",
+        createdAt: "2026-04-26T09:06:00.000Z",
+        payload: { routeName: "Route B" },
+      }),
+    ];
+
+    const queue = buildReviewQueue({
+      analyticsEvents,
+      palaceId: "palace-1",
+      now: "2026-04-26T09:10:00.000Z",
+      routes: [
+        { id: "route-a", palaceId: "palace-1", name: "Route A" },
+        { id: "route-b", palaceId: "palace-1", name: "Route B" },
+        { id: "route-c", palaceId: "palace-1", name: "Route C" },
+      ],
+      nodes: [
+        { id: "node-a", objectId: "object-a", title: "Node A", content: "", kind: "memory", portal: null },
+        { id: "node-b", objectId: "object-b", title: "Node B", content: "", kind: "memory", portal: null },
+        { id: "node-c", objectId: "object-c", title: "Node C", content: "", kind: "memory", portal: null },
+      ],
+    });
+
+    expect(queue.find((item) => item.kind === "route" && item.routeId === "route-a")).toMatchObject({
+      kind: "route",
+      routeId: "route-a",
+      state: "overdue",
+      latestRating: "again",
+    });
+    expect(queue.find((item) => item.kind === "node" && item.nodeId === "node-a")).toMatchObject({
+      kind: "node",
+      nodeId: "node-a",
+      state: "overdue",
+      latestRating: "again",
+    });
+    expect(queue.some((item) => item.kind === "route" && item.routeId === "route-c" && item.state === "fresh")).toBe(true);
+    expect(queue.some((item) => item.kind === "node" && item.nodeId === "node-c" && item.state === "fresh")).toBe(true);
+    expect(queue.some((item) => item.kind === "route" && item.routeId === "route-b" && item.state === "scheduled")).toBe(true);
+
+    const summary = summarizeReviewQueue(queue);
+    expect(summary.dueCount).toBe(2);
+    expect(summary.overdueCount).toBe(2);
+    expect(summary.freshCount).toBe(2);
+    expect(summary.routeItems).toBe(3);
+    expect(summary.nodeItems).toBe(3);
+  });
+});

--- a/src/domain/services/reviewQueueService.ts
+++ b/src/domain/services/reviewQueueService.ts
@@ -1,0 +1,296 @@
+import type { AnalyticsEvent, MemoryNode, MemoryRoute, RecallRating } from "../entities/types";
+import { parseAnalyticsPayload } from "./analyticsService";
+
+const MINUTE_MS = 60_000;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+export type ReviewQueueItemKind = "node" | "route";
+export type ReviewQueueState = "overdue" | "due_now" | "fresh" | "scheduled";
+
+export type ReviewQueueItem = {
+  id: string;
+  kind: ReviewQueueItemKind;
+  palaceId: string | null;
+  routeId: string | null;
+  nodeId: string | null;
+  title: string;
+  subtitle: string | null;
+  state: ReviewQueueState;
+  latestRating: RecallRating | null;
+  reviewedAt: string | null;
+  dueAt: string | null;
+  dueInMs: number | null;
+  sessionId: string | null;
+};
+
+type WalkRatingEvent = AnalyticsEvent & {
+  routeId: string;
+  nodeId: string;
+};
+
+type RouteSessionReview = {
+  sessionId: string;
+  routeId: string;
+  reviewedAt: string;
+  dueAt: string;
+  latestRating: RecallRating;
+};
+
+function reviewIntervalMsForRating(rating: RecallRating) {
+  switch (rating) {
+    case "again":
+      return 0;
+    case "hard":
+      return DAY_MS;
+    case "good":
+      return 3 * DAY_MS;
+    case "easy":
+      return 7 * DAY_MS;
+    default:
+      return MINUTE_MS;
+  }
+}
+
+function ratingRank(rating: RecallRating) {
+  switch (rating) {
+    case "again":
+      return 0;
+    case "hard":
+      return 1;
+    case "good":
+      return 2;
+    case "easy":
+      return 3;
+    default:
+      return 0;
+  }
+}
+
+function coerceRecallRating(value: unknown): RecallRating | null {
+  return value === "again" || value === "hard" || value === "good" || value === "easy" ? value : null;
+}
+
+function dueStateFromTime(dueAt: string | null, nowIso: string): ReviewQueueState {
+  if (!dueAt) return "fresh";
+  const nowMs = Date.parse(nowIso);
+  const dueMs = Date.parse(dueAt);
+  if (!Number.isFinite(nowMs) || !Number.isFinite(dueMs)) return "fresh";
+  if (dueMs > nowMs) return "scheduled";
+  if (nowMs - dueMs < MINUTE_MS) return "due_now";
+  return "overdue";
+}
+
+function queuePriority(state: ReviewQueueState) {
+  switch (state) {
+    case "overdue":
+      return 0;
+    case "due_now":
+      return 1;
+    case "fresh":
+      return 2;
+    case "scheduled":
+      return 3;
+    default:
+      return 4;
+  }
+}
+
+function buildRouteSessionReviews(events: AnalyticsEvent[]) {
+  const ratingsBySessionRoute = new Map<string, WalkRatingEvent[]>();
+  const closeEvents: Array<AnalyticsEvent & { routeId: string; sessionId: string }> = [];
+  const sessions = new Map<string, RouteSessionReview>();
+
+  for (const event of events) {
+    if (event.eventType === "walk_recall_rated" && event.routeId && event.nodeId && event.sessionId) {
+      const key = `${event.sessionId}:${event.routeId}`;
+      const list = ratingsBySessionRoute.get(key) ?? [];
+      list.push(event as WalkRatingEvent);
+      ratingsBySessionRoute.set(key, list);
+      continue;
+    }
+
+    if (event.eventType === "walk_closed" && event.routeId && event.sessionId) {
+      closeEvents.push(event as AnalyticsEvent & { routeId: string; sessionId: string });
+    }
+  }
+
+  for (const event of closeEvents) {
+    const key = `${event.sessionId}:${event.routeId}`;
+    const sessionRatings = ratingsBySessionRoute.get(key) ?? [];
+    const ratings = sessionRatings
+      .map((ratingEvent) => coerceRecallRating(parseAnalyticsPayload(ratingEvent).rating))
+      .filter((rating): rating is RecallRating => !!rating);
+    if (ratings.length === 0) continue;
+    const weakest = ratings.slice().sort((a, b) => ratingRank(a) - ratingRank(b))[0];
+    const dueAt = new Date(Date.parse(event.createdAt) + reviewIntervalMsForRating(weakest)).toISOString();
+    const existing = sessions.get(event.routeId);
+    if (existing && existing.reviewedAt >= event.createdAt) continue;
+    sessions.set(event.routeId, {
+      sessionId: event.sessionId,
+      routeId: event.routeId,
+      reviewedAt: event.createdAt,
+      dueAt,
+      latestRating: weakest,
+    });
+  }
+
+  return sessions;
+}
+
+export function buildReviewQueue(input: {
+  analyticsEvents: AnalyticsEvent[];
+  nodes: MemoryNode[];
+  routes: MemoryRoute[];
+  palaceId?: string | null;
+  now?: string;
+}) {
+  const now = input.now ?? new Date().toISOString();
+  const events = input.palaceId
+    ? input.analyticsEvents.filter((event) => event.palaceId === input.palaceId)
+    : input.analyticsEvents.slice();
+
+  const latestNodeRatingById = new Map<string, WalkRatingEvent>();
+  for (const event of events) {
+    if (event.eventType !== "walk_recall_rated" || !event.nodeId || !event.routeId) continue;
+    const current = latestNodeRatingById.get(event.nodeId);
+    if (!current || current.createdAt < event.createdAt) {
+      latestNodeRatingById.set(event.nodeId, event as WalkRatingEvent);
+    }
+  }
+
+  const latestRouteReviewById = buildRouteSessionReviews(events);
+  const knownNodes = new Map(input.nodes.map((node) => [node.id, node]));
+
+  for (const [nodeId, latest] of latestNodeRatingById.entries()) {
+    if (knownNodes.has(nodeId)) continue;
+    const payload = parseAnalyticsPayload(latest);
+    const fallbackTitle =
+      typeof payload.nodeTitle === "string" && payload.nodeTitle.trim() ? payload.nodeTitle.trim() : nodeId.slice(0, 8);
+    knownNodes.set(nodeId, {
+      id: nodeId,
+      objectId: `analytics:${nodeId}`,
+      title: fallbackTitle,
+      content: "",
+      kind: "memory",
+      portal: null,
+    });
+  }
+
+  const nodeItems: ReviewQueueItem[] = [...knownNodes.values()]
+    .filter((node) => node.kind !== "portal")
+    .map((node) => {
+      const latest = latestNodeRatingById.get(node.id);
+      if (!latest) {
+        return {
+          id: `node:${node.id}`,
+          kind: "node",
+          palaceId: input.palaceId ?? null,
+          routeId: null,
+          nodeId: node.id,
+          title: node.title || "Untitled node",
+          subtitle: "Fresh concept review",
+          state: "fresh",
+          latestRating: null,
+          reviewedAt: null,
+          dueAt: null,
+          dueInMs: null,
+          sessionId: null,
+        };
+      }
+
+      const payload = parseAnalyticsPayload(latest);
+      const latestRating = coerceRecallRating(payload.rating) ?? "again";
+      const dueAt = new Date(Date.parse(latest.createdAt) + reviewIntervalMsForRating(latestRating)).toISOString();
+      const state = dueStateFromTime(dueAt, now);
+      const payloadNodeTitle = typeof payload.nodeTitle === "string" && payload.nodeTitle.trim() ? payload.nodeTitle : null;
+      return {
+        id: `node:${node.id}`,
+        kind: "node",
+        palaceId: latest.palaceId ?? input.palaceId ?? null,
+        routeId: latest.routeId,
+        nodeId: node.id,
+        title: payloadNodeTitle ?? node.title ?? "Untitled node",
+        subtitle: typeof payload.routeName === "string" ? payload.routeName : "Single concept review",
+        state,
+        latestRating,
+        reviewedAt: latest.createdAt,
+        dueAt,
+        dueInMs: Date.parse(dueAt) - Date.parse(now),
+        sessionId: latest.sessionId ?? null,
+      };
+    });
+
+  const routeItems: ReviewQueueItem[] = input.routes.map((route) => {
+    const latest = latestRouteReviewById.get(route.id);
+    if (!latest) {
+      return {
+        id: `route:${route.id}`,
+        kind: "route",
+        palaceId: input.palaceId ?? route.palaceId,
+        routeId: route.id,
+        nodeId: null,
+        title: route.name,
+        subtitle: "Fresh route review",
+        state: "fresh",
+        latestRating: null,
+        reviewedAt: null,
+        dueAt: null,
+        dueInMs: null,
+        sessionId: null,
+      };
+    }
+
+    const state = dueStateFromTime(latest.dueAt, now);
+    return {
+      id: `route:${route.id}`,
+      kind: "route",
+      palaceId: input.palaceId ?? route.palaceId,
+      routeId: route.id,
+      nodeId: null,
+      title: route.name,
+      subtitle: "Whole-route review",
+      state,
+      latestRating: latest.latestRating,
+      reviewedAt: latest.reviewedAt,
+      dueAt: latest.dueAt,
+      dueInMs: Date.parse(latest.dueAt) - Date.parse(now),
+      sessionId: latest.sessionId,
+    };
+  });
+
+  const items = [...routeItems, ...nodeItems].sort((a, b) => {
+    const priorityDelta = queuePriority(a.state) - queuePriority(b.state);
+    if (priorityDelta !== 0) return priorityDelta;
+    const dueA = a.dueAt ? Date.parse(a.dueAt) : Number.POSITIVE_INFINITY;
+    const dueB = b.dueAt ? Date.parse(b.dueAt) : Number.POSITIVE_INFINITY;
+    if (dueA !== dueB) return dueA - dueB;
+    if (a.kind !== b.kind) return a.kind === "route" ? -1 : 1;
+    return a.title.localeCompare(b.title);
+  });
+
+  return items;
+}
+
+export function summarizeReviewQueue(items: ReviewQueueItem[]) {
+  return items.reduce(
+    (summary, item) => {
+      summary.total += 1;
+      if (item.kind === "route") summary.routeItems += 1;
+      if (item.kind === "node") summary.nodeItems += 1;
+      if (item.state === "overdue" || item.state === "due_now") summary.dueCount += 1;
+      if (item.state === "overdue") summary.overdueCount += 1;
+      if (item.state === "fresh") summary.freshCount += 1;
+      if (item.state === "scheduled") summary.scheduledCount += 1;
+      return summary;
+    },
+    {
+      total: 0,
+      dueCount: 0,
+      overdueCount: 0,
+      freshCount: 0,
+      scheduledCount: 0,
+      routeItems: 0,
+      nodeItems: 0,
+    },
+  );
+}

--- a/src/store/palaceStore.ts
+++ b/src/store/palaceStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import type { Editor } from "@tldraw/editor";
+import type { TLShapeId } from "@tldraw/tlschema";
 import type {
   AnalyticsEvent,
   AnalyticsEventGroup,
@@ -13,6 +14,8 @@ import type {
   RecallRating,
 } from "../domain/entities/types";
 import { buildPalaceSnapshot } from "../canvas/buildPalaceSnapshot";
+import type { MemoryPalaceMeta } from "../canvas/memoryMeta";
+import { resolveMemoryNodeTitle } from "../canvas/readShapeText";
 import { createAnalyticsEvent } from "../domain/services/analyticsService";
 import { getPalaceRepository } from "../infrastructure/palaceRepositoryProvider";
 import { clearPalaceDraft, loadPalaceDraft, savePalaceDraft } from "../infrastructure/draft/palaceDraftStore";
@@ -57,6 +60,7 @@ export type PalaceStore = {
   walkOpen: boolean;
   walkRouteId: string | null;
   walkIndex: number;
+  walkSessionId: string | null;
   walkRecallMode: boolean;
   walkCueOnly: boolean;
   walkAnswerRevealed: boolean;
@@ -183,6 +187,21 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
     };
   };
 
+  const resolveNodeTitleForAnalytics = (nodeId: string | null) => {
+    if (!nodeId) return null;
+    const { editorRef, nodes } = get();
+    if (editorRef) {
+      for (const shapeId of editorRef.getCurrentPageShapeIds()) {
+        const shape = editorRef.getShape(shapeId as TLShapeId);
+        if (shape?.type !== "geo") continue;
+        const meta = (shape.meta ?? {}) as MemoryPalaceMeta;
+        if (meta.mpNodeId !== nodeId) continue;
+        return resolveMemoryNodeTitle(shape);
+      }
+    }
+    return nodes.find((node) => node.id === nodeId)?.title ?? null;
+  };
+
   const noteWalkStepEntered = (direction: "open" | "next" | "prev" | "route_change") => {
     const enteredAt = new Date().toISOString();
     set((state) => ({
@@ -196,6 +215,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
     void recordAnalytics({
       eventType: "walk_stepped",
       eventGroup: "review",
+      sessionId: get().walkSessionId,
       palaceId: context.palaceId,
       routeId: context.routeId,
       nodeId: context.nodeId,
@@ -205,6 +225,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
         routeLength: context.count,
         locusId: context.locus?.id ?? null,
         routeName: context.routeName,
+        nodeTitle: resolveNodeTitleForAnalytics(context.nodeId),
       },
     });
   };
@@ -265,6 +286,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
     walkOpen: false,
     walkRouteId: null,
     walkIndex: 0,
+    walkSessionId: null,
     walkRecallMode: false,
     walkCueOnly: true,
     walkAnswerRevealed: true,
@@ -498,6 +520,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
         walkRouteId: routes[0]?.id ?? null,
         walkIndex: 0,
         walkOpen: false,
+        walkSessionId: null,
         walkAnswerRevealed: !get().walkRecallMode,
         walkStepEnteredAt: null,
         walkRevealedAt: null,
@@ -576,27 +599,49 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
     },
 
     setWalkRoute(walkRouteId) {
-      const wasOpen = get().walkOpen;
+      const state = get();
+      const wasOpen = state.walkOpen;
+      const previousContext = getWalkContext();
+      const previousWalkSessionId = state.walkSessionId;
+      const nextWalkSessionId = wasOpen && walkRouteId ? crypto.randomUUID() : null;
       set((state) => ({
         walkRouteId,
         walkIndex: 0,
+        walkSessionId: nextWalkSessionId,
         walkAnswerRevealed: !state.walkRecallMode,
         walkStepEnteredAt: null,
         walkRevealedAt: null,
         walkRevealLatencyMs: null,
       }));
       if (!wasOpen || !walkRouteId) return;
+      if (previousContext.routeId && previousWalkSessionId) {
+        void recordAnalytics({
+          eventType: "walk_closed",
+          eventGroup: "review",
+          sessionId: previousWalkSessionId,
+          routeId: previousContext.routeId,
+          nodeId: previousContext.nodeId,
+          payload: {
+            stepIndex: previousContext.stepIndex,
+            routeLength: previousContext.count,
+            routeName: previousContext.routeName,
+            nodeTitle: resolveNodeTitleForAnalytics(previousContext.nodeId),
+          },
+        });
+      }
       const context = getWalkContext();
       if (context.routeId) {
         void recordAnalytics({
           eventType: "walk_started",
           eventGroup: "review",
+          sessionId: nextWalkSessionId,
           routeId: context.routeId,
           nodeId: context.nodeId,
           payload: {
             source: "route_change",
             routeLength: context.count,
             routeName: context.routeName,
+            nodeTitle: resolveNodeTitleForAnalytics(context.nodeId),
           },
         });
       }
@@ -606,9 +651,11 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       const state = get();
       const wasOpen = state.walkOpen;
       const previousContext = getWalkContext();
+      const nextWalkSessionId = walkOpen && !wasOpen ? crypto.randomUUID() : walkOpen ? state.walkSessionId : null;
       set({
         walkOpen,
         walkIndex: walkOpen && !wasOpen ? 0 : state.walkIndex,
+        walkSessionId: nextWalkSessionId,
         walkAnswerRevealed: walkOpen ? !state.walkRecallMode : false,
         walkStepEnteredAt: walkOpen ? state.walkStepEnteredAt : null,
         walkRevealedAt: null,
@@ -620,12 +667,14 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
           void recordAnalytics({
             eventType: "walk_closed",
             eventGroup: "review",
+            sessionId: state.walkSessionId,
             routeId: previousContext.routeId,
             nodeId: previousContext.nodeId,
             payload: {
               stepIndex: previousContext.stepIndex,
               routeLength: previousContext.count,
               routeName: previousContext.routeName,
+              nodeTitle: resolveNodeTitleForAnalytics(previousContext.nodeId),
             },
           });
         }
@@ -639,12 +688,14 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
           void recordAnalytics({
             eventType: "walk_started",
             eventGroup: "review",
+            sessionId: nextWalkSessionId,
             routeId: context.routeId,
             nodeId: context.nodeId,
             payload: {
               source: "toggle",
               routeLength: context.count,
               routeName: context.routeName,
+              nodeTitle: resolveNodeTitleForAnalytics(context.nodeId),
             },
           });
         }
@@ -681,6 +732,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       void recordAnalytics({
         eventType: "walk_answer_revealed",
         eventGroup: "review",
+        sessionId: get().walkSessionId,
         routeId: context.routeId,
         nodeId: context.nodeId,
         payload: {
@@ -688,6 +740,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
           routeLength: context.count,
           locusId: context.locus?.id ?? null,
           routeName: context.routeName,
+          nodeTitle: resolveNodeTitleForAnalytics(context.nodeId),
           timeToRevealMs,
         },
       });
@@ -711,6 +764,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
       void recordAnalytics({
         eventType: "walk_recall_rated",
         eventGroup: "review",
+        sessionId: get().walkSessionId,
         routeId: context.routeId,
         nodeId: context.nodeId,
         payload: {
@@ -719,6 +773,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
           routeLength: context.count,
           locusId: context.locus?.id ?? null,
           routeName: context.routeName,
+          nodeTitle: resolveNodeTitleForAnalytics(context.nodeId),
           timeToRevealMs,
           timeFromRevealToRatingMs,
         },
@@ -764,6 +819,7 @@ export const usePalaceStore = create<PalaceStore>((set, get) => {
         walkRouteId: s.routes[0]?.id ?? null,
         walkIndex: 0,
         walkOpen: false,
+        walkSessionId: null,
         walkAnswerRevealed: !state.walkRecallMode,
         walkStepEnteredAt: null,
         walkRevealedAt: null,

--- a/tests/ui/essential-workflows.spec.ts
+++ b/tests/ui/essential-workflows.spec.ts
@@ -50,6 +50,19 @@ async function queuePendingCast(page: import("@playwright/test").Page, fromIndex
   );
 }
 
+async function waitForEditorReady(page: import("@playwright/test").Page) {
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const store = (window as { __mp_store?: { getState: () => unknown } }).__mp_store;
+        if (!store) return false;
+        const state = store.getState() as { editorRef: unknown | null };
+        return !!state.editorRef;
+      }),
+    )
+    .toBe(true);
+}
+
 test("palace save/load workflow", async ({ page }) => {
   await bootstrapTutorialPalace(page);
 
@@ -85,6 +98,7 @@ test("draft autosave restores unsaved work after switching palaces", async ({ pa
   await page.getByRole("button", { name: "Draft Palace", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Draft Palace" })).toBeVisible();
   await expect(page.getByText("Draft restored")).toBeVisible();
+  await waitForEditorReady(page);
 
   await page.evaluate(() => {
     const store = (window as { __mp_store?: { getState: () => unknown } }).__mp_store;
@@ -164,6 +178,39 @@ test("analytics panel shows local review and graph telemetry", async ({ page }) 
   await expect(page.getByText("Recent events")).toBeVisible();
   await expect(page.getByText(/walk recall rated/i)).toBeVisible();
   await expect(page.getByText(/graph work: node create\/update, edge create\/update/i)).toBeVisible();
+});
+
+test("spaced review queue surfaces due node and route reviews", async ({ page }) => {
+  await bootstrapTutorialPalace(page);
+
+  await page.getByRole("button", { name: /^Node$/ }).click();
+  await page.locator("#mp-title").fill("Queue Node");
+  await page.locator("#mp-content").fill("Queue content for spaced review.");
+  await page.getByRole("button", { name: "Apply" }).click();
+
+  await page.getByPlaceholder("Route name").fill("Spaced Route");
+  await page.getByRole("button", { name: "Add route" }).click();
+  await page.getByRole("button", { name: /add selected node to route/i }).click();
+
+  await page.getByRole("button", { name: "Toggle walk mode" }).click();
+  await page.getByRole("button", { name: "Recall-first" }).click();
+  await page.getByRole("button", { name: "Reveal answer" }).click();
+  await page.getByRole("button", { name: "Fail" }).click();
+  await page.getByRole("button", { name: "Toggle walk mode" }).click();
+
+  await expect(page.getByRole("button", { name: "2 due" })).toBeVisible();
+  await page.getByRole("button", { name: "2 due" }).click();
+
+  await expect(page.getByText("Review Queue", { exact: true })).toBeVisible();
+  const routeCard = page.locator("section").filter({ has: page.getByRole("button", { name: "Review route" }) }).first();
+  const nodeCard = page.locator("section").filter({ has: page.getByRole("button", { name: "Focus node" }) }).first();
+  await expect(routeCard.getByText("Spaced Route", { exact: true })).toBeVisible();
+  await expect(nodeCard.getByText("Queue Node", { exact: true })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Review route" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Review route" }).click();
+  await expect(page.getByRole("button", { name: "Recall-first" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Reveal answer" })).toBeVisible();
 });
 
 test("connect workflow opens and applies CAST", async ({ page }) => {


### PR DESCRIPTION
## Summary
- derive node and route review items from recall-first analytics
- surface due and overdue review work in the header and learn panel
- allow restarting route and node review flows directly from the queue

## Verification
- npm.cmd run typecheck
- npm.cmd test
- npx.cmd playwright test --workers=1
- npm.cmd run build
- cargo check