### PR TITLE
Add memory strength dashboard

### DIFF
--- a/src/canvas/MemoryPalaceCanvas.tsx
+++ b/src/canvas/MemoryPalaceCanvas.tsx
@@ -129,7 +129,7 @@ export function MemoryPalaceCanvas({ palaceId, editorSnapshot }: Props) {
           const ids = editor.getSelectedShapeIds();
           setSelectedShapeId(ids.length === 1 ? ids[0] : null);
         },
-        { source: "user", scope: "document" },
+        { source: "all", scope: "session" },
       );
 
       const unsubDraft = editor.store.listen(

--- a/src/components/MemoryStrengthDashboard.tsx
+++ b/src/components/MemoryStrengthDashboard.tsx
@@ -1,0 +1,471 @@
+import { useEffect, useMemo, type ReactNode } from "react";
+import type { TLShapeId } from "@tldraw/tlschema";
+import {
+  Activity,
+  AlertTriangle,
+  BrainCircuit,
+  Flame,
+  LineChart,
+  Mountain,
+  Orbit,
+  Route,
+  Target,
+} from "lucide-react";
+import type { MemoryPalaceMeta } from "../canvas/memoryMeta";
+import {
+  buildMemoryStrengthDashboard,
+  formatDashboardUrgency,
+  formatRouteFrictionStatus,
+  formatTrendDirection,
+  type DashboardUrgency,
+  type MemoryStrengthActionItem,
+  type PalaceHealthItem,
+  type RouteFrictionStatus,
+  type TrendPoint,
+} from "../domain/services/memoryStrengthService";
+import { orderedLoci } from "../domain/services/walkService";
+import { usePalaceStore } from "../store/palaceStore";
+import { Button } from "./ui/button";
+
+function StatCard({
+  icon,
+  label,
+  value,
+  tone = "zinc",
+}: {
+  icon: ReactNode;
+  label: string;
+  value: string;
+  tone?: "zinc" | "amber" | "emerald" | "violet";
+}) {
+  const toneClass =
+    tone === "amber"
+      ? "border-amber-700/70 bg-amber-950/20"
+      : tone === "emerald"
+        ? "border-emerald-700/70 bg-emerald-950/20"
+        : tone === "violet"
+          ? "border-violet-700/70 bg-violet-950/20"
+          : "border-zinc-800 bg-zinc-900/40";
+
+  return (
+    <div className={`rounded-md border p-3 ${toneClass}`}>
+      <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-zinc-400">
+        {icon}
+        {label}
+      </div>
+      <div className="mt-2 text-2xl font-semibold text-zinc-100">{value}</div>
+    </div>
+  );
+}
+
+function actionToneClass(urgency: DashboardUrgency) {
+  switch (urgency) {
+    case "critical":
+      return "border-rose-700/70 bg-rose-950/20";
+    case "weak":
+      return "border-amber-700/70 bg-amber-950/20";
+    case "stable":
+      return "border-zinc-800 bg-zinc-900/40";
+    case "strong":
+      return "border-emerald-700/70 bg-emerald-950/20";
+    default:
+      return "border-zinc-800 bg-zinc-900/40";
+  }
+}
+
+function frictionToneClass(status: RouteFrictionStatus) {
+  switch (status) {
+    case "cognitively_expensive":
+      return "border-rose-700/70 bg-rose-950/20";
+    case "unstable":
+      return "border-amber-700/70 bg-amber-950/20";
+    case "steady":
+      return "border-emerald-700/70 bg-emerald-950/20";
+    default:
+      return "border-zinc-800 bg-zinc-900/40";
+  }
+}
+
+function percent(value: number | null) {
+  if (value === null) return "n/a";
+  return `${value}%`;
+}
+
+function formatAtlasPath(path: string | null) {
+  return path?.trim() ? path : "Ungrouped";
+}
+
+function formatDueState(state: MemoryStrengthActionItem["state"]) {
+  switch (state) {
+    case "overdue":
+      return "Overdue";
+    case "due_now":
+      return "Due now";
+    case "scheduled":
+      return "Scheduled";
+    case "fresh":
+      return "Fresh";
+    default:
+      return "Fresh";
+  }
+}
+
+function formatRevealLatency(ms: number | null) {
+  if (ms === null) return "n/a";
+  if (ms < 1_000) return `${ms} ms`;
+  return `${(ms / 1_000).toFixed(1)} s`;
+}
+
+function trendBarHeight(point: TrendPoint) {
+  if (point.averageScore === null) return 12;
+  return Math.max(12, Math.round(point.averageScore));
+}
+
+export function MemoryStrengthDashboard() {
+  const palaces = usePalaceStore((s) => s.palaces);
+  const currentPalace = usePalaceStore((s) => s.currentPalace);
+  const nodes = usePalaceStore((s) => s.nodes);
+  const routes = usePalaceStore((s) => s.routes);
+  const analyticsEvents = usePalaceStore((s) => s.analyticsEvents);
+  const analyticsLoaded = usePalaceStore((s) => s.analyticsLoaded);
+  const loadAnalyticsEvents = usePalaceStore((s) => s.loadAnalyticsEvents);
+  const openPalace = usePalaceStore((s) => s.openPalace);
+  const setWalkRoute = usePalaceStore((s) => s.setWalkRoute);
+  const setWalkRecallMode = usePalaceStore((s) => s.setWalkRecallMode);
+  const setWalkCueOnly = usePalaceStore((s) => s.setWalkCueOnly);
+  const setWalkOpen = usePalaceStore((s) => s.setWalkOpen);
+
+  useEffect(() => {
+    if (!analyticsLoaded) {
+      void loadAnalyticsEvents();
+    }
+  }, [analyticsLoaded, loadAnalyticsEvents]);
+
+  const dashboard = useMemo(
+    () =>
+      buildMemoryStrengthDashboard({
+        analyticsEvents,
+        palaces,
+        nodes,
+        routes,
+      }),
+    [analyticsEvents, nodes, palaces, routes],
+  );
+
+  const ensurePalaceOpen = async (palaceId: string | null) => {
+    if (!palaceId) return false;
+    if (usePalaceStore.getState().currentPalace?.id === palaceId) return true;
+    await openPalace(palaceId);
+    return true;
+  };
+
+  const waitForEditor = async (palaceId: string, timeoutMs = 5_000) => {
+    const maxAttempts = Math.max(1, Math.ceil(timeoutMs / 50));
+    for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      const state = usePalaceStore.getState();
+      if (state.currentPalace?.id === palaceId && state.editorRef) {
+        return state.editorRef;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    return null;
+  };
+
+  const focusNode = async (palaceId: string | null, nodeId: string | null) => {
+    if (!palaceId || !nodeId) return;
+    const opened = await ensurePalaceOpen(palaceId);
+    if (!opened) return;
+    const editorRef = await waitForEditor(palaceId);
+    if (!editorRef) return;
+    for (const shapeId of editorRef.getCurrentPageShapeIds()) {
+      const shape = editorRef.getShape(shapeId);
+      if (shape?.type !== "geo") continue;
+      const meta = (shape.meta ?? {}) as MemoryPalaceMeta;
+      if (meta.mpNodeId !== nodeId) continue;
+      editorRef.setSelectedShapes([shapeId as TLShapeId]);
+      usePalaceStore.getState().setSelectedShapeId(shapeId);
+      editorRef.zoomToSelectionIfOffscreen(120, { animation: { duration: 220 } });
+      break;
+    }
+  };
+
+  const reviewRoute = async (palaceId: string | null, routeId: string | null) => {
+    if (!palaceId || !routeId) return;
+    const opened = await ensurePalaceOpen(palaceId);
+    if (!opened) return;
+    setWalkRoute(routeId);
+    setWalkRecallMode(true);
+    setWalkCueOnly(true);
+    setWalkOpen(true);
+  };
+
+  const reviewNode = async (item: MemoryStrengthActionItem) => {
+    if (!item.nodeId) return;
+    if (!item.routeId) {
+      await focusNode(item.palaceId, item.nodeId);
+      return;
+    }
+    await reviewRoute(item.palaceId, item.routeId);
+    const state = usePalaceStore.getState();
+    const routeLoci = orderedLoci(state.loci.filter((locus) => locus.routeId === item.routeId));
+    const targetIndex = routeLoci.findIndex((locus) => locus.nodeId === item.nodeId);
+    if (targetIndex >= 0) {
+      usePalaceStore.setState({ walkIndex: targetIndex });
+    }
+  };
+
+  if (palaces.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 items-center justify-center rounded-md border border-dashed border-zinc-800 bg-zinc-950/40 p-6 text-sm text-zinc-500">
+        Create a palace and review a route to generate memory strength analytics.
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="border-b border-zinc-800 pb-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-violet-200">
+          <LineChart className="h-4 w-4" />
+          Memory strength
+        </div>
+        <p className="mt-1 max-w-3xl text-xs leading-5 text-zinc-400">
+          This dashboard turns review telemetry into action. It surfaces weak material first, shows palace health and
+          trend direction, and marks routes that are becoming cognitively expensive.
+        </p>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto py-3">
+        <div className="grid gap-3 md:grid-cols-4">
+          <StatCard
+            icon={<Target className="h-3.5 w-3.5" />}
+            label="Average strength"
+            value={percent(dashboard.overview.averageStrength)}
+            tone="violet"
+          />
+          <StatCard
+            icon={<AlertTriangle className="h-3.5 w-3.5" />}
+            label="Due now"
+            value={String(dashboard.overview.totalDue)}
+            tone="amber"
+          />
+          <StatCard
+            icon={<Flame className="h-3.5 w-3.5" />}
+            label="Overdue"
+            value={String(dashboard.overview.totalOverdue)}
+            tone={dashboard.overview.totalOverdue > 0 ? "amber" : "zinc"}
+          />
+          <StatCard
+            icon={<Activity className="h-3.5 w-3.5" />}
+            label="Trend"
+            value={formatTrendDirection(dashboard.overview.trendDirection)}
+            tone="emerald"
+          />
+        </div>
+
+        <div className="mt-3 rounded-md border border-zinc-800 bg-zinc-900/40 p-3 text-xs leading-5 text-zinc-400">
+          Active palaces: <span className="text-zinc-200">{dashboard.overview.activePalaces}</span>. Review sessions:{" "}
+          <span className="text-zinc-200">{dashboard.overview.reviewSessions}</span>. Current palace:{" "}
+          <span className="text-zinc-200">{currentPalace?.name ?? "none"}</span>.
+        </div>
+
+        <div className="mt-3 grid gap-3 xl:grid-cols-[1.1fr_0.9fr]">
+          <section className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-zinc-100">
+              <BrainCircuit className="h-4 w-4 text-violet-300" />
+              Action queue
+            </div>
+            <div className="mt-3 space-y-3">
+              {dashboard.actionItems.length === 0 ? (
+                <div className="rounded-md border border-dashed border-zinc-800 bg-zinc-950/40 px-3 py-5 text-sm text-zinc-500">
+                  No prioritized review items yet. Grade a recall session to start scoring strength.
+                </div>
+              ) : (
+                dashboard.actionItems.map((item) => (
+                  <section key={item.id} className={`rounded-md border p-3 ${actionToneClass(item.urgency)}`}>
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-zinc-500">
+                          {item.kind === "route" ? <Route className="h-3.5 w-3.5" /> : <Orbit className="h-3.5 w-3.5" />}
+                          {item.kind}
+                          <span>{formatDashboardUrgency(item.urgency)}</span>
+                        </div>
+                        <div className="mt-1 text-sm font-semibold text-zinc-100">{item.title}</div>
+                        <div className="mt-1 text-xs text-zinc-400">{item.subtitle}</div>
+                        <div className="mt-2 text-xs text-zinc-500">
+                          {item.palaceName} / {formatAtlasPath(item.palaceAtlasPath)}
+                        </div>
+                        <div className="mt-2 grid gap-2 text-xs text-zinc-400 sm:grid-cols-3">
+                          <div>State: {formatDueState(item.state)}</div>
+                          <div>Last grade: {item.latestRating ?? "none"}</div>
+                          <div>Strength: {percent(item.strengthScore)}</div>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap justify-end gap-2">
+                        {item.kind === "route" ? (
+                          <Button type="button" size="sm" onClick={() => void reviewRoute(item.palaceId, item.routeId)}>
+                            Review route
+                          </Button>
+                        ) : (
+                          <Button type="button" size="sm" onClick={() => void reviewNode(item)}>
+                            {item.routeId ? "Review node" : "Focus node"}
+                          </Button>
+                        )}
+                        <Button type="button" size="sm" variant="secondary" onClick={() => void ensurePalaceOpen(item.palaceId)}>
+                          Open palace
+                        </Button>
+                      </div>
+                    </div>
+                  </section>
+                ))
+              )}
+            </div>
+          </section>
+
+          <section className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-zinc-100">
+              <LineChart className="h-4 w-4 text-violet-300" />
+              Recall trend
+            </div>
+            <div className="mt-2 text-xs text-zinc-400">
+              Overall trend: <span className="text-zinc-200">{formatTrendDirection(dashboard.overview.trendDirection)}</span>
+              {dashboard.overview.trendDelta !== null ? (
+                <span className="text-zinc-500"> ({dashboard.overview.trendDelta > 0 ? "+" : ""}{dashboard.overview.trendDelta})</span>
+              ) : null}
+            </div>
+            <div className="mt-4 grid grid-cols-7 gap-2">
+              {dashboard.trend.map((point) => (
+                <div key={point.dayKey} className="flex flex-col items-center gap-2">
+                  <div className="flex h-36 w-full items-end justify-center rounded-md border border-zinc-800 bg-zinc-950/40 px-1 py-2">
+                    <div
+                      className={`w-full rounded-sm ${
+                        point.averageScore === null
+                          ? "bg-zinc-700/50"
+                          : point.averageScore >= 80
+                            ? "bg-emerald-500/80"
+                            : point.averageScore >= 60
+                              ? "bg-violet-500/80"
+                              : point.averageScore >= 40
+                                ? "bg-amber-500/80"
+                                : "bg-rose-500/80"
+                      }`}
+                      style={{ height: `${trendBarHeight(point)}%` }}
+                    />
+                  </div>
+                  <div className="text-[11px] text-zinc-500">{point.label}</div>
+                  <div className="text-[11px] text-zinc-400">{point.reviewCount} reviews</div>
+                </div>
+              ))}
+            </div>
+          </section>
+        </div>
+
+        <div className="mt-3 grid gap-3 xl:grid-cols-[0.95fr_1.05fr]">
+          <section className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-zinc-100">
+              <Mountain className="h-4 w-4 text-violet-300" />
+              Palace health
+            </div>
+            <div className="mt-3 space-y-3">
+              {dashboard.palaceHealth.map((palace) => (
+                <PalaceHealthCard key={palace.palaceId} palace={palace} onOpen={() => void ensurePalaceOpen(palace.palaceId)} />
+              ))}
+            </div>
+          </section>
+
+          <section className="rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+            <div className="flex items-center gap-2 text-sm font-medium text-zinc-100">
+              <Route className="h-4 w-4 text-violet-300" />
+              Route friction
+            </div>
+            <div className="mt-3 space-y-3">
+              {dashboard.routeFriction.length === 0 ? (
+                <div className="rounded-md border border-dashed border-zinc-800 bg-zinc-950/40 px-3 py-5 text-sm text-zinc-500">
+                  No route friction yet. Review more than one route step to reveal hesitation patterns.
+                </div>
+              ) : (
+                dashboard.routeFriction.map((route) => (
+                  <section key={route.routeId} className={`rounded-md border p-3 ${frictionToneClass(route.status)}`}>
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-zinc-500">
+                          <Route className="h-3.5 w-3.5" />
+                          {formatRouteFrictionStatus(route.status)}
+                        </div>
+                        <div className="mt-1 text-sm font-semibold text-zinc-100">{route.routeName}</div>
+                        <div className="mt-1 text-xs text-zinc-400">
+                          {route.palaceName} / {formatAtlasPath(route.palaceAtlasPath)}
+                        </div>
+                        <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-zinc-800">
+                          <div
+                            className={`h-full rounded-full ${
+                              route.status === "cognitively_expensive"
+                                ? "bg-rose-500"
+                                : route.status === "unstable"
+                                  ? "bg-amber-500"
+                                  : "bg-emerald-500"
+                            }`}
+                            style={{ width: `${route.frictionScore}%` }}
+                          />
+                        </div>
+                        <div className="mt-3 grid gap-2 text-xs text-zinc-400 sm:grid-cols-3">
+                          <div>Attempts: {route.attemptCount}</div>
+                          <div>Fail rate: {Math.round(route.failureRate * 100)}%</div>
+                          <div>Hard rate: {Math.round(route.hardRate * 100)}%</div>
+                          <div>Reveal time: {formatRevealLatency(route.averageRevealLatencyMs)}</div>
+                          <div>Due state: {route.dueState ? formatDueState(route.dueState) : "Fresh"}</div>
+                          <div>Friction: {percent(route.frictionScore)}</div>
+                        </div>
+                      </div>
+                      <div className="flex flex-wrap justify-end gap-2">
+                        <Button type="button" size="sm" onClick={() => void reviewRoute(route.palaceId, route.routeId)}>
+                          Review route
+                        </Button>
+                        <Button type="button" size="sm" variant="secondary" onClick={() => void ensurePalaceOpen(route.palaceId)}>
+                          Open palace
+                        </Button>
+                      </div>
+                    </div>
+                  </section>
+                ))
+              )}
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PalaceHealthCard({ palace, onOpen }: { palace: PalaceHealthItem; onOpen: () => void }) {
+  const barTone =
+    palace.healthScore >= 80 ? "bg-emerald-500" : palace.healthScore >= 60 ? "bg-violet-500" : palace.healthScore >= 40 ? "bg-amber-500" : "bg-rose-500";
+
+  return (
+    <section className="rounded-md border border-zinc-800 bg-zinc-950/40 p-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-semibold text-zinc-100">{palace.palaceName}</div>
+          <div className="mt-1 text-xs text-zinc-500">{formatAtlasPath(palace.atlasPath)}</div>
+          <div className="mt-3 h-2 w-full overflow-hidden rounded-full bg-zinc-800">
+            <div className={`h-full rounded-full ${barTone}`} style={{ width: `${palace.healthScore}%` }} />
+          </div>
+          <div className="mt-3 grid gap-2 text-xs text-zinc-400 sm:grid-cols-3">
+            <div>Health: {percent(palace.healthScore)}</div>
+            <div>Trend: {formatTrendDirection(palace.trendDirection)}</div>
+            <div>Reviews: {palace.reviewCount}</div>
+            <div>Due: {palace.dueCount}</div>
+            <div>Overdue: {palace.overdueCount}</div>
+            <div>Weak items: {palace.weakItems}</div>
+          </div>
+          <div className="mt-2 text-xs text-zinc-500">
+            Hotspot: <span className="text-zinc-300">{palace.hotspotTitle ?? "none yet"}</span>
+          </div>
+        </div>
+        <Button type="button" size="sm" variant="secondary" onClick={onOpen}>
+          Open palace
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/OnboardingPanel.tsx
+++ b/src/components/OnboardingPanel.tsx
@@ -9,6 +9,7 @@ import { Button } from "./ui/button";
 import type { MemoryPalaceMeta } from "../canvas/memoryMeta";
 import type { Locus, MemoryRoute } from "../domain/entities/types";
 import { AnalyticsPanel } from "./AnalyticsPanel";
+import { MemoryStrengthDashboard } from "./MemoryStrengthDashboard";
 import { ReviewQueuePanel } from "./ReviewQueuePanel";
 import { TheSystemWorkbench } from "./TheSystemWorkbench";
 
@@ -99,7 +100,7 @@ const EXAMPLES: ExampleBlueprint[] = [
   },
 ];
 
-export type LearnPanelTab = "guides" | "system" | "analytics" | "review";
+export type LearnPanelTab = "guides" | "system" | "dashboard" | "analytics" | "review";
 
 type Props = {
   open: boolean;
@@ -446,6 +447,14 @@ export function OnboardingPanel({ open, onClose, preferredTab }: Props) {
           <Button
             size="sm"
             type="button"
+            variant={panelTab === "dashboard" ? "default" : "secondary"}
+            onClick={() => setPanelTab("dashboard")}
+          >
+            Dashboard
+          </Button>
+          <Button
+            size="sm"
+            type="button"
             variant={panelTab === "review" ? "default" : "secondary"}
             onClick={() => setPanelTab("review")}
           >
@@ -554,6 +563,10 @@ export function OnboardingPanel({ open, onClose, preferredTab }: Props) {
       ) : panelTab === "system" ? (
         <div className="min-h-0 flex-1 p-3">
           <TheSystemWorkbench />
+        </div>
+      ) : panelTab === "dashboard" ? (
+        <div className="min-h-0 flex-1 p-3">
+          <MemoryStrengthDashboard />
         </div>
       ) : panelTab === "review" ? (
         <div className="min-h-0 flex-1 p-3">

--- a/src/domain/services/memoryStrengthService.test.ts
+++ b/src/domain/services/memoryStrengthService.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, it } from "vitest";
+import type { RecallRating } from "../entities/types";
+import { createAnalyticsEvent } from "./analyticsService";
+import { buildMemoryStrengthDashboard } from "./memoryStrengthService";
+
+function makeRouteCreated(palaceId: string, routeId: string, name: string, createdAt: string) {
+  return createAnalyticsEvent({
+    eventType: "route_created",
+    eventGroup: "graph",
+    palaceId,
+    routeId,
+    createdAt,
+    payload: { name },
+  });
+}
+
+function makeReviewSession(input: {
+  palaceId: string;
+  routeId: string;
+  routeName: string;
+  nodeId: string;
+  nodeTitle: string;
+  sessionId: string;
+  createdAt: string;
+  rating: RecallRating;
+  timeToRevealMs: number;
+}) {
+  return [
+    createAnalyticsEvent({
+      eventType: "walk_recall_rated",
+      eventGroup: "review",
+      sessionId: input.sessionId,
+      palaceId: input.palaceId,
+      routeId: input.routeId,
+      nodeId: input.nodeId,
+      createdAt: input.createdAt,
+      payload: {
+        rating: input.rating,
+        routeName: input.routeName,
+        nodeTitle: input.nodeTitle,
+        timeToRevealMs: input.timeToRevealMs,
+      },
+    }),
+    createAnalyticsEvent({
+      eventType: "walk_closed",
+      eventGroup: "review",
+      sessionId: input.sessionId,
+      palaceId: input.palaceId,
+      routeId: input.routeId,
+      nodeId: input.nodeId,
+      createdAt: new Date(Date.parse(input.createdAt) + 60_000).toISOString(),
+      payload: {
+        routeName: input.routeName,
+        nodeTitle: input.nodeTitle,
+      },
+    }),
+  ];
+}
+
+describe("memoryStrengthService", () => {
+  it("prioritizes weak overdue material and marks fragile routes", () => {
+    const palaces = [
+      { id: "palace-weak", name: "Weak Palace", createdAt: "2026-04-20T08:00:00.000Z", atlasPath: "Georgia/Tbilisi" },
+      { id: "palace-strong", name: "Strong Palace", createdAt: "2026-04-20T08:00:00.000Z", atlasPath: "Georgia/Batumi" },
+    ];
+    const events = [
+      makeRouteCreated("palace-weak", "route-weak", "Weak Route", "2026-04-20T08:00:00.000Z"),
+      ...makeReviewSession({
+        palaceId: "palace-weak",
+        routeId: "route-weak",
+        routeName: "Weak Route",
+        nodeId: "node-weak",
+        nodeTitle: "Weak Node",
+        sessionId: "weak-1",
+        createdAt: "2026-04-20T09:00:00.000Z",
+        rating: "again",
+        timeToRevealMs: 18_000,
+      }),
+      makeRouteCreated("palace-strong", "route-strong", "Strong Route", "2026-04-24T08:00:00.000Z"),
+      ...makeReviewSession({
+        palaceId: "palace-strong",
+        routeId: "route-strong",
+        routeName: "Strong Route",
+        nodeId: "node-strong",
+        nodeTitle: "Strong Node",
+        sessionId: "strong-1",
+        createdAt: "2026-04-24T09:00:00.000Z",
+        rating: "easy",
+        timeToRevealMs: 900,
+      }),
+    ];
+
+    const dashboard = buildMemoryStrengthDashboard({
+      analyticsEvents: events,
+      palaces,
+      now: "2026-04-26T12:00:00.000Z",
+    });
+
+    expect(dashboard.overview.totalDue).toBe(2);
+    expect(dashboard.actionItems.some((item) => item.title === "Weak Route" && item.palaceName === "Weak Palace")).toBe(true);
+    expect(dashboard.actionItems.some((item) => item.title === "Weak Node" && item.urgency === "critical")).toBe(true);
+    expect(dashboard.palaceHealth[0]).toMatchObject({
+      palaceName: "Weak Palace",
+      dueCount: 2,
+      overdueCount: 2,
+    });
+    expect(dashboard.routeFriction[0]).toMatchObject({
+      routeName: "Weak Route",
+      palaceName: "Weak Palace",
+      status: "cognitively_expensive",
+    });
+  });
+
+  it("tracks improving and decaying palace trends from repeated review history", () => {
+    const palaces = [
+      { id: "palace-up", name: "Improving Palace", createdAt: "2026-04-20T08:00:00.000Z" },
+      { id: "palace-down", name: "Decaying Palace", createdAt: "2026-04-20T08:00:00.000Z" },
+    ];
+    const improvingRatings: RecallRating[] = ["again", "hard", "good", "good", "easy", "easy"];
+    const decayingRatings: RecallRating[] = ["easy", "easy", "good", "good", "hard", "again"];
+    const events = [
+      makeRouteCreated("palace-up", "route-up", "Improving Route", "2026-04-20T08:00:00.000Z"),
+      makeRouteCreated("palace-down", "route-down", "Decaying Route", "2026-04-20T08:00:00.000Z"),
+      ...improvingRatings.flatMap((rating, index) =>
+        makeReviewSession({
+          palaceId: "palace-up",
+          routeId: "route-up",
+          routeName: "Improving Route",
+          nodeId: `node-up-${index}`,
+          nodeTitle: `Improving Node ${index}`,
+          sessionId: `up-${index}`,
+          createdAt: `2026-04-${String(20 + index).padStart(2, "0")}T09:00:00.000Z`,
+          rating,
+          timeToRevealMs: 5_000 - index * 500,
+        }),
+      ),
+      ...decayingRatings.flatMap((rating, index) =>
+        makeReviewSession({
+          palaceId: "palace-down",
+          routeId: "route-down",
+          routeName: "Decaying Route",
+          nodeId: `node-down-${index}`,
+          nodeTitle: `Decaying Node ${index}`,
+          sessionId: `down-${index}`,
+          createdAt: `2026-04-${String(20 + index).padStart(2, "0")}T11:00:00.000Z`,
+          rating,
+          timeToRevealMs: 1_500 + index * 1_500,
+        }),
+      ),
+    ];
+
+    const dashboard = buildMemoryStrengthDashboard({
+      analyticsEvents: events,
+      palaces,
+      now: "2026-04-26T12:00:00.000Z",
+    });
+
+    const improving = dashboard.palaceHealth.find((item) => item.palaceId === "palace-up");
+    const decaying = dashboard.palaceHealth.find((item) => item.palaceId === "palace-down");
+
+    expect(improving?.trendDirection).toBe("improving");
+    expect(decaying?.trendDirection).toBe("decaying");
+    expect(dashboard.trend).toHaveLength(7);
+  });
+});

--- a/src/domain/services/memoryStrengthService.ts
+++ b/src/domain/services/memoryStrengthService.ts
@@ -1,0 +1,630 @@
+import type { AnalyticsEvent, MemoryNode, MemoryRoute, Palace, RecallRating } from "../entities/types";
+import { parseAnalyticsPayload } from "./analyticsService";
+import { buildReviewQueue, type ReviewQueueItem, type ReviewQueueState } from "./reviewQueueService";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const UNKNOWN_PALACE_ID = "__unknown_palace__";
+
+const RATING_SCORES: Record<RecallRating, number> = {
+  again: 15,
+  hard: 45,
+  good: 78,
+  easy: 96,
+};
+
+export type TrendDirection = "improving" | "stagnating" | "decaying" | "insufficient";
+export type DashboardUrgency = "critical" | "weak" | "stable" | "strong";
+export type RouteFrictionStatus = "cognitively_expensive" | "unstable" | "steady";
+
+export type MemoryStrengthActionItem = {
+  id: string;
+  kind: "node" | "route";
+  palaceId: string | null;
+  palaceName: string;
+  palaceAtlasPath: string | null;
+  routeId: string | null;
+  nodeId: string | null;
+  title: string;
+  subtitle: string;
+  state: ReviewQueueState;
+  latestRating: RecallRating | null;
+  reviewedAt: string | null;
+  dueAt: string | null;
+  strengthScore: number;
+  urgency: DashboardUrgency;
+};
+
+export type PalaceHealthItem = {
+  palaceId: string;
+  palaceName: string;
+  atlasPath: string | null;
+  healthScore: number;
+  trendDirection: TrendDirection;
+  trendDelta: number | null;
+  dueCount: number;
+  overdueCount: number;
+  weakItems: number;
+  totalTrackedItems: number;
+  reviewCount: number;
+  hotspotTitle: string | null;
+};
+
+export type TrendPoint = {
+  dayKey: string;
+  label: string;
+  reviewCount: number;
+  averageScore: number | null;
+  againCount: number;
+  hardCount: number;
+  goodCount: number;
+  easyCount: number;
+};
+
+export type RouteFrictionItem = {
+  routeId: string;
+  routeName: string;
+  palaceId: string | null;
+  palaceName: string;
+  palaceAtlasPath: string | null;
+  attemptCount: number;
+  averageRevealLatencyMs: number | null;
+  failureRate: number;
+  hardRate: number;
+  frictionScore: number;
+  status: RouteFrictionStatus;
+  dueState: ReviewQueueState | null;
+};
+
+export type MemoryStrengthDashboard = {
+  overview: {
+    totalDue: number;
+    totalOverdue: number;
+    averageStrength: number | null;
+    activePalaces: number;
+    reviewSessions: number;
+    trendDirection: TrendDirection;
+    trendDelta: number | null;
+  };
+  actionItems: MemoryStrengthActionItem[];
+  palaceHealth: PalaceHealthItem[];
+  trend: TrendPoint[];
+  routeFriction: RouteFrictionItem[];
+};
+
+type PalaceMeta = {
+  id: string;
+  name: string;
+  atlasPath: string | null;
+};
+
+type NodeMeta = {
+  id: string;
+  palaceId: string | null;
+  title: string;
+};
+
+type RouteMeta = {
+  id: string;
+  palaceId: string | null;
+  name: string;
+};
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function average(values: number[]) {
+  if (!values.length) return null;
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function reviewStatePenalty(state: ReviewQueueState) {
+  switch (state) {
+    case "overdue":
+      return 25;
+    case "due_now":
+      return 15;
+    case "fresh":
+      return 0;
+    case "scheduled":
+      return -4;
+    default:
+      return 0;
+  }
+}
+
+function scoreFromRating(rating: RecallRating | null) {
+  if (!rating) return 58;
+  return RATING_SCORES[rating];
+}
+
+function scoreFromReviewItem(item: ReviewQueueItem) {
+  const base = scoreFromRating(item.latestRating);
+  if (item.latestRating === null && item.state === "fresh") {
+    return 58;
+  }
+  return clamp(Math.round(base - reviewStatePenalty(item.state)), 0, 100);
+}
+
+function urgencyFromScore(score: number): DashboardUrgency {
+  if (score < 35) return "critical";
+  if (score < 60) return "weak";
+  if (score < 85) return "stable";
+  return "strong";
+}
+
+function trendDirectionFromDelta(delta: number | null): TrendDirection {
+  if (delta === null) return "insufficient";
+  if (delta >= 8) return "improving";
+  if (delta <= -8) return "decaying";
+  return "stagnating";
+}
+
+function formatPalaceFallback(palaceId: string | null) {
+  if (!palaceId) return "Unknown palace";
+  return `Palace ${palaceId.slice(0, 8)}`;
+}
+
+function makeTrendLabel(dayKey: string) {
+  const [year, month, day] = dayKey.split("-").map((part) => Number(part));
+  const date = new Date(Date.UTC(year, (month || 1) - 1, day || 1));
+  return date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+function startOfUtcDayMs(iso: string) {
+  const date = new Date(iso);
+  return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+function coerceRecallRating(value: unknown): RecallRating | null {
+  return value === "again" || value === "hard" || value === "good" || value === "easy" ? value : null;
+}
+
+function trendSummaryFromPoints(points: TrendPoint[]) {
+  const scored = points.filter((point) => point.averageScore !== null);
+  if (scored.length < 2) {
+    return { direction: "insufficient" as TrendDirection, delta: null };
+  }
+  const recent = scored.slice(-3).map((point) => point.averageScore ?? 0);
+  const previous = scored.slice(Math.max(0, scored.length - 6), scored.length - 3).map((point) => point.averageScore ?? 0);
+  if (previous.length === 0) {
+    return { direction: "insufficient" as TrendDirection, delta: null };
+  }
+  const delta = Math.round((average(recent) ?? 0) - (average(previous) ?? 0));
+  return {
+    direction: trendDirectionFromDelta(delta),
+    delta,
+  };
+}
+
+function buildTrendSeries(events: AnalyticsEvent[], now: string, days: number) {
+  const buckets = new Map<string, Array<{ score: number; rating: RecallRating }>>();
+  const endDayMs = startOfUtcDayMs(now);
+
+  for (const event of events) {
+    if (event.eventType !== "walk_recall_rated") continue;
+    const payload = parseAnalyticsPayload(event);
+    const rating = coerceRecallRating(payload.rating);
+    if (!rating) continue;
+    const dayKey = event.createdAt.slice(0, 10);
+    const values = buckets.get(dayKey) ?? [];
+    values.push({ score: scoreFromRating(rating), rating });
+    buckets.set(dayKey, values);
+  }
+
+  const points: TrendPoint[] = [];
+  for (let offset = days - 1; offset >= 0; offset -= 1) {
+    const dayMs = endDayMs - offset * DAY_MS;
+    const dayKey = new Date(dayMs).toISOString().slice(0, 10);
+    const ratings = buckets.get(dayKey) ?? [];
+    const scores = ratings.map((entry) => entry.score);
+    points.push({
+      dayKey,
+      label: makeTrendLabel(dayKey),
+      reviewCount: ratings.length,
+      averageScore: scores.length ? Math.round(average(scores) ?? 0) : null,
+      againCount: ratings.filter((entry) => entry.rating === "again").length,
+      hardCount: ratings.filter((entry) => entry.rating === "hard").length,
+      goodCount: ratings.filter((entry) => entry.rating === "good").length,
+      easyCount: ratings.filter((entry) => entry.rating === "easy").length,
+    });
+  }
+
+  return points;
+}
+
+function buildEntityMetadata(input: {
+  analyticsEvents: AnalyticsEvent[];
+  palaces: Palace[];
+  nodes: MemoryNode[];
+  routes: MemoryRoute[];
+}) {
+  const palaceById = new Map<string, PalaceMeta>();
+  const nodeById = new Map<string, NodeMeta>();
+  const routeById = new Map<string, RouteMeta>();
+
+  for (const palace of input.palaces) {
+    palaceById.set(palace.id, {
+      id: palace.id,
+      name: palace.name,
+      atlasPath: palace.atlasPath ?? null,
+    });
+  }
+
+  for (const node of input.nodes) {
+    nodeById.set(node.id, {
+      id: node.id,
+      palaceId: null,
+      title: node.title,
+    });
+  }
+
+  for (const route of input.routes) {
+    routeById.set(route.id, {
+      id: route.id,
+      palaceId: route.palaceId,
+      name: route.name,
+    });
+  }
+
+  for (const event of input.analyticsEvents) {
+    const payload = parseAnalyticsPayload(event);
+
+    if (event.eventType === "palace_created" && event.palaceId) {
+      const fallback = palaceById.get(event.palaceId);
+      const name =
+        typeof payload.name === "string" && payload.name.trim() ? payload.name.trim() : fallback?.name ?? formatPalaceFallback(event.palaceId);
+      const atlasPath =
+        typeof payload.atlasPath === "string" && payload.atlasPath.trim()
+          ? payload.atlasPath.trim()
+          : fallback?.atlasPath ?? null;
+      palaceById.set(event.palaceId, {
+        id: event.palaceId,
+        name,
+        atlasPath,
+      });
+    }
+
+    if (event.nodeId) {
+      const fallback = nodeById.get(event.nodeId);
+      const titleFromPayload =
+        typeof payload.nodeTitle === "string" && payload.nodeTitle.trim()
+          ? payload.nodeTitle.trim()
+          : typeof payload.title === "string" && payload.title.trim()
+            ? payload.title.trim()
+            : fallback?.title ?? event.nodeId.slice(0, 8);
+      nodeById.set(event.nodeId, {
+        id: event.nodeId,
+        palaceId: fallback?.palaceId ?? event.palaceId ?? null,
+        title: titleFromPayload,
+      });
+    }
+
+    if (event.routeId) {
+      const fallback = routeById.get(event.routeId);
+      const nameFromPayload =
+        typeof payload.routeName === "string" && payload.routeName.trim()
+          ? payload.routeName.trim()
+          : typeof payload.name === "string" && payload.name.trim()
+            ? payload.name.trim()
+            : fallback?.name ?? event.routeId.slice(0, 8);
+      routeById.set(event.routeId, {
+        id: event.routeId,
+        palaceId: fallback?.palaceId ?? event.palaceId ?? null,
+        name: nameFromPayload,
+      });
+    }
+  }
+
+  return { palaceById, nodeById, routeById };
+}
+
+function synthesizeNodes(nodeById: Map<string, NodeMeta>): MemoryNode[] {
+  return [...nodeById.values()].map((node) => ({
+    id: node.id,
+    objectId: `analytics:${node.id}`,
+    title: node.title,
+    content: "",
+    kind: "memory",
+    portal: null,
+  }));
+}
+
+function synthesizeRoutes(routeById: Map<string, RouteMeta>): MemoryRoute[] {
+  return [...routeById.values()].map((route) => ({
+    id: route.id,
+    palaceId: route.palaceId ?? UNKNOWN_PALACE_ID,
+    name: route.name,
+  }));
+}
+
+function buildActionItems(
+  queue: ReviewQueueItem[],
+  palaceById: Map<string, PalaceMeta>,
+  limit: number,
+): MemoryStrengthActionItem[] {
+  const prioritized = queue.filter((item) => item.latestRating !== null || item.state !== "fresh");
+  const source = prioritized.length > 0 ? prioritized : queue;
+  return source.slice(0, limit).map((item) => {
+    const palace = item.palaceId ? palaceById.get(item.palaceId) : null;
+    const strengthScore = scoreFromReviewItem(item);
+    return {
+      id: item.id,
+      kind: item.kind,
+      palaceId: item.palaceId && item.palaceId !== UNKNOWN_PALACE_ID ? item.palaceId : null,
+      palaceName: palace?.name ?? formatPalaceFallback(item.palaceId ?? null),
+      palaceAtlasPath: palace?.atlasPath ?? null,
+      routeId: item.routeId,
+      nodeId: item.nodeId,
+      title: item.title,
+      subtitle: item.subtitle ?? (item.kind === "route" ? "Route review" : "Node review"),
+      state: item.state,
+      latestRating: item.latestRating,
+      reviewedAt: item.reviewedAt,
+      dueAt: item.dueAt,
+      strengthScore,
+      urgency: urgencyFromScore(strengthScore),
+    };
+  });
+}
+
+function buildPalaceHealthItems(input: {
+  queue: ReviewQueueItem[];
+  analyticsEvents: AnalyticsEvent[];
+  palaces: Map<string, PalaceMeta>;
+  actionItems: MemoryStrengthActionItem[];
+  now: string;
+  trendDays: number;
+}) {
+  const palaceIds = new Set<string>();
+  for (const item of input.queue) {
+    if (item.palaceId && item.palaceId !== UNKNOWN_PALACE_ID) {
+      palaceIds.add(item.palaceId);
+    }
+  }
+  for (const palaceId of input.palaces.keys()) {
+    palaceIds.add(palaceId);
+  }
+
+  const items: PalaceHealthItem[] = [];
+  for (const palaceId of palaceIds) {
+    const palace = input.palaces.get(palaceId);
+    const queueItems = input.queue.filter((item) => item.palaceId === palaceId);
+    const reviewEvents = input.analyticsEvents.filter(
+      (event) => event.palaceId === palaceId && event.eventType === "walk_recall_rated",
+    );
+    const strengths = queueItems.map((item) => scoreFromReviewItem(item));
+    const dueCount = queueItems.filter((item) => item.state === "due_now" || item.state === "overdue").length;
+    const overdueCount = queueItems.filter((item) => item.state === "overdue").length;
+    const weakItems = queueItems.filter((item) => urgencyFromScore(scoreFromReviewItem(item)) === "critical" || urgencyFromScore(scoreFromReviewItem(item)) === "weak").length;
+    const averageStrength = average(strengths);
+    const penalty =
+      queueItems.length > 0 ? Math.round((overdueCount * 18 + dueCount * 8 + weakItems * 5) / queueItems.length) : 0;
+    const trendPoints = buildTrendSeries(
+      input.analyticsEvents.filter((event) => event.palaceId === palaceId),
+      input.now,
+      input.trendDays,
+    );
+    const trendSummary = trendSummaryFromPoints(trendPoints);
+    const hotspot = input.actionItems.find((item) => item.palaceId === palaceId)?.title ?? null;
+    items.push({
+      palaceId,
+      palaceName: palace?.name ?? formatPalaceFallback(palaceId),
+      atlasPath: palace?.atlasPath ?? null,
+      healthScore: clamp(Math.round((averageStrength ?? 58) - penalty), 0, 100),
+      trendDirection: trendSummary.direction,
+      trendDelta: trendSummary.delta,
+      dueCount,
+      overdueCount,
+      weakItems,
+      totalTrackedItems: queueItems.length,
+      reviewCount: reviewEvents.length,
+      hotspotTitle: hotspot,
+    });
+  }
+
+  return items.sort((a, b) => a.healthScore - b.healthScore || b.overdueCount - a.overdueCount || a.palaceName.localeCompare(b.palaceName));
+}
+
+function buildRouteFrictionItems(input: {
+  analyticsEvents: AnalyticsEvent[];
+  routeById: Map<string, RouteMeta>;
+  palaceById: Map<string, PalaceMeta>;
+  routeDueStateById: Map<string, ReviewQueueState>;
+}) {
+  const ratingsByRoute = new Map<
+    string,
+    {
+      palaceId: string | null;
+      scoreTotal: number;
+      attempts: number;
+      againCount: number;
+      hardCount: number;
+      revealLatencies: number[];
+    }
+  >();
+
+  for (const event of input.analyticsEvents) {
+    if (event.eventType !== "walk_recall_rated" || !event.routeId) continue;
+    const payload = parseAnalyticsPayload(event);
+    const rating = coerceRecallRating(payload.rating);
+    if (!rating) continue;
+    const entry = ratingsByRoute.get(event.routeId) ?? {
+      palaceId: event.palaceId ?? null,
+      scoreTotal: 0,
+      attempts: 0,
+      againCount: 0,
+      hardCount: 0,
+      revealLatencies: [],
+    };
+    entry.scoreTotal += scoreFromRating(rating);
+    entry.attempts += 1;
+    if (rating === "again") entry.againCount += 1;
+    if (rating === "hard") entry.hardCount += 1;
+    if (typeof payload.timeToRevealMs === "number" && Number.isFinite(payload.timeToRevealMs) && payload.timeToRevealMs >= 0) {
+      entry.revealLatencies.push(payload.timeToRevealMs);
+    }
+    ratingsByRoute.set(event.routeId, entry);
+  }
+
+  const items: RouteFrictionItem[] = [];
+  for (const [routeId, entry] of ratingsByRoute.entries()) {
+    if (entry.attempts === 0) continue;
+    const averageScore = entry.scoreTotal / entry.attempts;
+    const averageRevealLatencyMs = average(entry.revealLatencies);
+    const lowConfidenceRate = (entry.againCount + entry.hardCount) / entry.attempts;
+    const failureRate = entry.againCount / entry.attempts;
+    const hardRate = entry.hardCount / entry.attempts;
+    const latencyPenalty =
+      averageRevealLatencyMs === null ? 0 : clamp(((averageRevealLatencyMs - 4_000) / 12_000) * 18, 0, 18);
+    const dueState = input.routeDueStateById.get(routeId) ?? null;
+    const duePenalty = dueState === "overdue" ? 15 : dueState === "due_now" ? 8 : 0;
+    const frictionScore = clamp(Math.round((100 - averageScore) * 0.72 + lowConfidenceRate * 22 + latencyPenalty + duePenalty), 0, 100);
+    const status: RouteFrictionStatus =
+      frictionScore >= 70 ? "cognitively_expensive" : frictionScore >= 45 ? "unstable" : "steady";
+    const route = input.routeById.get(routeId);
+    const palace = route?.palaceId ? input.palaceById.get(route.palaceId) : null;
+    items.push({
+      routeId,
+      routeName: route?.name ?? routeId.slice(0, 8),
+      palaceId: route?.palaceId ?? entry.palaceId ?? null,
+      palaceName: palace?.name ?? formatPalaceFallback(route?.palaceId ?? entry.palaceId ?? null),
+      palaceAtlasPath: palace?.atlasPath ?? null,
+      attemptCount: entry.attempts,
+      averageRevealLatencyMs: averageRevealLatencyMs === null ? null : Math.round(averageRevealLatencyMs),
+      failureRate: Number(failureRate.toFixed(2)),
+      hardRate: Number(hardRate.toFixed(2)),
+      frictionScore,
+      status,
+      dueState,
+    });
+  }
+
+  return items.sort((a, b) => b.frictionScore - a.frictionScore || a.routeName.localeCompare(b.routeName));
+}
+
+export function buildMemoryStrengthDashboard(input: {
+  analyticsEvents: AnalyticsEvent[];
+  palaces: Palace[];
+  nodes?: MemoryNode[];
+  routes?: MemoryRoute[];
+  now?: string;
+  trendDays?: number;
+  actionItemLimit?: number;
+}): MemoryStrengthDashboard {
+  const now = input.now ?? new Date().toISOString();
+  const trendDays = input.trendDays ?? 7;
+  const actionItemLimit = input.actionItemLimit ?? 8;
+  const nodes = input.nodes ?? [];
+  const routes = input.routes ?? [];
+  const metadata = buildEntityMetadata({
+    analyticsEvents: input.analyticsEvents,
+    palaces: input.palaces,
+    nodes,
+    routes,
+  });
+  const queue = buildReviewQueue({
+    analyticsEvents: input.analyticsEvents,
+    nodes: synthesizeNodes(metadata.nodeById),
+    routes: synthesizeRoutes(metadata.routeById),
+    now,
+  }).map((item) => {
+    const routePalaceId = item.routeId ? metadata.routeById.get(item.routeId)?.palaceId ?? null : null;
+    const nodePalaceId = item.nodeId ? metadata.nodeById.get(item.nodeId)?.palaceId ?? null : null;
+    const palaceId = item.palaceId && item.palaceId !== UNKNOWN_PALACE_ID ? item.palaceId : routePalaceId ?? nodePalaceId ?? null;
+    return {
+      ...item,
+      palaceId,
+    };
+  });
+
+  const actionItems = buildActionItems(queue, metadata.palaceById, actionItemLimit);
+  const routeDueStateById = new Map<string, ReviewQueueState>(
+    queue.filter((item) => item.kind === "route" && item.routeId).map((item) => [item.routeId!, item.state]),
+  );
+  const palaceHealth = buildPalaceHealthItems({
+    queue,
+    analyticsEvents: input.analyticsEvents,
+    palaces: metadata.palaceById,
+    actionItems,
+    now,
+    trendDays,
+  });
+  const trend = buildTrendSeries(input.analyticsEvents, now, trendDays);
+  const trendSummary = trendSummaryFromPoints(trend);
+  const routeFriction = buildRouteFrictionItems({
+    analyticsEvents: input.analyticsEvents,
+    routeById: metadata.routeById,
+    palaceById: metadata.palaceById,
+    routeDueStateById,
+  });
+  const averageStrength = average(actionItems.map((item) => item.strengthScore));
+  const reviewSessions = new Set(
+    input.analyticsEvents
+      .filter((event) => (event.eventType === "walk_closed" || event.eventType === "walk_started") && event.sessionId)
+      .map((event) => event.sessionId as string),
+  ).size;
+
+  return {
+    overview: {
+      totalDue: queue.filter((item) => item.state === "due_now" || item.state === "overdue").length,
+      totalOverdue: queue.filter((item) => item.state === "overdue").length,
+      averageStrength: averageStrength === null ? null : Math.round(averageStrength),
+      activePalaces: palaceHealth.filter((item) => item.totalTrackedItems > 0 || item.reviewCount > 0).length,
+      reviewSessions,
+      trendDirection: trendSummary.direction,
+      trendDelta: trendSummary.delta,
+    },
+    actionItems,
+    palaceHealth,
+    trend,
+    routeFriction,
+  };
+}
+
+export function formatTrendDirection(direction: TrendDirection) {
+  switch (direction) {
+    case "improving":
+      return "Improving";
+    case "decaying":
+      return "Decaying";
+    case "stagnating":
+      return "Stagnating";
+    case "insufficient":
+      return "Not enough data";
+    default:
+      return "Not enough data";
+  }
+}
+
+export function formatDashboardUrgency(urgency: DashboardUrgency) {
+  switch (urgency) {
+    case "critical":
+      return "Critical";
+    case "weak":
+      return "Weak";
+    case "stable":
+      return "Stable";
+    case "strong":
+      return "Strong";
+    default:
+      return "Stable";
+  }
+}
+
+export function formatRouteFrictionStatus(status: RouteFrictionStatus) {
+  switch (status) {
+    case "cognitively_expensive":
+      return "Cognitively expensive";
+    case "unstable":
+      return "Unstable";
+    case "steady":
+      return "Steady";
+    default:
+      return "Steady";
+  }
+}

--- a/tests/ui/essential-workflows.spec.ts
+++ b/tests/ui/essential-workflows.spec.ts
@@ -213,6 +213,51 @@ test("spaced review queue surfaces due node and route reviews", async ({ page })
   await expect(page.getByRole("button", { name: "Reveal answer" })).toBeVisible();
 });
 
+test("memory strength dashboard opens weak route review across palaces", async ({ page }) => {
+  await page.goto("/");
+  await page.getByRole("textbox", { name: "Name", exact: true }).fill("Dashboard Source");
+  await page.getByRole("button", { name: "Create palace" }).click();
+  await expect(page.getByRole("heading", { name: "Dashboard Source" })).toBeVisible();
+
+  await page.getByRole("textbox", { name: "Name", exact: true }).fill("Weak Palace");
+  await page.getByRole("button", { name: "Create palace" }).click();
+  await expect(page.getByRole("heading", { name: "Weak Palace" })).toBeVisible();
+
+  await page.getByRole("button", { name: /^Node$/ }).click();
+  await page.locator("#mp-title").fill("Weak Concept");
+  await page.locator("#mp-content").fill("Hard to recall answer.");
+  await page.getByRole("button", { name: "Apply" }).click();
+
+  await page.getByPlaceholder("Route name").fill("Weak Route");
+  await page.getByRole("button", { name: "Add route" }).click();
+  await page.getByRole("button", { name: /add selected node to route/i }).click();
+
+  await page.getByRole("button", { name: "Toggle walk mode" }).click();
+  await page.getByRole("button", { name: "Recall-first" }).click();
+  await page.getByRole("button", { name: "Reveal answer" }).click();
+  await page.getByRole("button", { name: "Fail" }).click();
+  await page.getByRole("button", { name: "Toggle walk mode" }).click();
+
+  await page.getByRole("button", { name: "Dashboard Source", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Dashboard Source" })).toBeVisible();
+
+  await page.getByRole("button", { name: "Learn" }).click();
+  await page.getByRole("button", { name: "Dashboard", exact: true }).click();
+  await expect(page.getByText(/memory strength/i)).toBeVisible();
+
+  const weakRouteCard = page
+    .locator("section")
+    .filter({ hasText: "Weak Route" })
+    .filter({ has: page.getByRole("button", { name: "Review route" }) })
+    .first();
+  await expect(weakRouteCard).toContainText("Weak Palace");
+  await weakRouteCard.getByRole("button", { name: "Review route" }).click();
+
+  await expect(page.getByRole("heading", { name: "Weak Palace" })).toBeVisible();
+  await expect(page.getByText("Step 1/1")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Reveal answer" })).toBeVisible();
+});
+
 test("connect workflow opens and applies CAST", async ({ page }) => {
   await bootstrapTutorialPalace(page);
 

--- a/tests/ui/node-editor.spec.ts
+++ b/tests/ui/node-editor.spec.ts
@@ -8,7 +8,7 @@ async function bootstrapPalace(page: import("@playwright/test").Page, name = "No
 }
 
 async function createNodeByDoubleClick(page: import("@playwright/test").Page) {
-  await page.locator(".tl-background").first().dblclick({ position: { x: 160, y: 180 } });
+  await page.getByRole("button", { name: /^Node$/ }).click();
 }
 
 async function createNodeByDoubleClickAt(page: import("@playwright/test").Page, x: number, y: number) {
@@ -111,11 +111,6 @@ test("node title/content persist after save and reopen palace", async ({ page })
 });
 
 test("inspector title matches clicked canvas node", async ({ page }) => {
-  test.fail(
-    true,
-    "Known regression: clicking a node can leave inspector bound to a different node selection.",
-  );
-
   await bootstrapPalace(page, "Selection Sync Palace");
 
   await createNodeByDoubleClickAt(page, 180, 160);


### PR DESCRIPTION
## Summary
- add a memory strength dashboard driven by review analytics across palaces
- surface action queues, palace health, trend data, and route friction with direct review actions
- fix selection sync so the inspector tracks canvas selection reliably and cover the new flows in tests

## Verification
- npm.cmd run typecheck
- npm.cmd test
- npx.cmd playwright test --workers=1
- npm.cmd run build
- cargo check